### PR TITLE
Replace empty defaults with self assignments

### DIFF
--- a/rca.v
+++ b/rca.v
@@ -478,7 +478,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_1[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_1[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_1 = sbox_dout_aes_128_clk_1;
         endcase
     end else begin
         sbox_dout_aes_128_clk_1 = 128'h0;
@@ -497,7 +497,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_1[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_1[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_1 = sbox_kout_aes_128_clk_1;
         endcase
     end else begin
         sbox_kout_aes_128_clk_1 = 32'h0;
@@ -516,7 +516,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_2[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_2[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_2 = sbox_kout_aes_128_clk_2;
         endcase
     end else begin
         sbox_kout_aes_128_clk_2 = 32'h0;
@@ -541,7 +541,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_2[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_2[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_2 = sbox_dout_aes_128_clk_2;
         endcase
     end else begin
         sbox_dout_aes_128_clk_2 = 128'h0;
@@ -566,7 +566,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_3[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_3[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_3 = sbox_dout_aes_128_clk_3;
         endcase
     end else begin
         sbox_dout_aes_128_clk_3 = 128'h0;
@@ -585,7 +585,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_3[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_3[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_3 = sbox_kout_aes_128_clk_3;
         endcase
     end else begin
         sbox_kout_aes_128_clk_3 = 32'h0;
@@ -604,7 +604,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_4[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_4[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_4 = sbox_kout_aes_128_clk_4;
         endcase
     end else begin
         sbox_kout_aes_128_clk_4 = 32'h0;
@@ -629,7 +629,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_4[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_4[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_4 = sbox_dout_aes_128_clk_4;
         endcase
     end else begin
         sbox_dout_aes_128_clk_4 = 128'h0;
@@ -654,7 +654,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_5[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_5[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_5 = sbox_dout_aes_128_clk_5;
         endcase
     end else begin
         sbox_dout_aes_128_clk_5 = 128'h0;
@@ -673,7 +673,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_5[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_5[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_5 = sbox_kout_aes_128_clk_5;
         endcase
     end else begin
         sbox_kout_aes_128_clk_5 = 32'h0;
@@ -692,7 +692,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_6[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_6[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_6 = sbox_kout_aes_128_clk_6;
         endcase
     end else begin
         sbox_kout_aes_128_clk_6 = 32'h0;
@@ -717,7 +717,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_6[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_6[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_6 = sbox_dout_aes_128_clk_6;
         endcase
     end else begin
         sbox_dout_aes_128_clk_6 = 128'h0;
@@ -742,7 +742,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_7[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_7[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_7 = sbox_dout_aes_128_clk_7;
         endcase
     end else begin
         sbox_dout_aes_128_clk_7 = 128'h0;
@@ -761,7 +761,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_7[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_7[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_7 = sbox_kout_aes_128_clk_7;
         endcase
     end else begin
         sbox_kout_aes_128_clk_7 = 32'h0;
@@ -780,7 +780,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_8[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_8[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_8 = sbox_kout_aes_128_clk_8;
         endcase
     end else begin
         sbox_kout_aes_128_clk_8 = 32'h0;
@@ -805,7 +805,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_8[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_8[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_8 = sbox_dout_aes_128_clk_8;
         endcase
     end else begin
         sbox_dout_aes_128_clk_8 = 128'h0;
@@ -830,7 +830,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_9[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_9[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_9 = sbox_dout_aes_128_clk_9;
         endcase
     end else begin
         sbox_dout_aes_128_clk_9 = 128'h0;
@@ -849,7 +849,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_9[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_9[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_9 = sbox_kout_aes_128_clk_9;
         endcase
     end else begin
         sbox_kout_aes_128_clk_9 = 32'h0;
@@ -868,7 +868,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_a[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_a[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_a = sbox_kout_aes_128_clk_a;
         endcase
     end else begin
         sbox_kout_aes_128_clk_a = 32'h0;
@@ -893,7 +893,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_a[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_a[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_a = sbox_dout_aes_128_clk_a;
         endcase
     end else begin
         sbox_dout_aes_128_clk_a = 128'h0;
@@ -918,7 +918,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_b[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_b[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_b = sbox_dout_aes_128_clk_b;
         endcase
     end else begin
         sbox_dout_aes_128_clk_b = 128'h0;
@@ -937,7 +937,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_b[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_b[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_b = sbox_kout_aes_128_clk_b;
         endcase
     end else begin
         sbox_kout_aes_128_clk_b = 32'h0;
@@ -956,7 +956,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_c[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_c[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_c = sbox_kout_aes_128_clk_c;
         endcase
     end else begin
         sbox_kout_aes_128_clk_c = 32'h0;
@@ -981,7 +981,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_c[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_c[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_c = sbox_dout_aes_128_clk_c;
         endcase
     end else begin
         sbox_dout_aes_128_clk_c = 128'h0;
@@ -1006,7 +1006,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_d[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_d[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_d = sbox_dout_aes_128_clk_d;
         endcase
     end else begin
         sbox_dout_aes_128_clk_d = 128'h0;
@@ -1025,7 +1025,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_d[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_d[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_d = sbox_kout_aes_128_clk_d;
         endcase
     end else begin
         sbox_kout_aes_128_clk_d = 32'h0;
@@ -1044,7 +1044,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_e[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_e[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_e = sbox_kout_aes_128_clk_e;
         endcase
     end else begin
         sbox_kout_aes_128_clk_e = 32'h0;
@@ -1069,7 +1069,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_e[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_e[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_e = sbox_dout_aes_128_clk_e;
         endcase
     end else begin
         sbox_dout_aes_128_clk_e = 128'h0;
@@ -1094,7 +1094,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_f[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_f[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_f = sbox_dout_aes_128_clk_f;
         endcase
     end else begin
         sbox_dout_aes_128_clk_f = 128'h0;
@@ -1113,7 +1113,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_f[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_f[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_f = sbox_kout_aes_128_clk_f;
         endcase
     end else begin
         sbox_kout_aes_128_clk_f = 32'h0;
@@ -1132,7 +1132,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_10[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_10[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_10 = sbox_kout_aes_128_clk_10;
         endcase
     end else begin
         sbox_kout_aes_128_clk_10 = 32'h0;
@@ -1157,7 +1157,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_10[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_10[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_10 = sbox_dout_aes_128_clk_10;
         endcase
     end else begin
         sbox_dout_aes_128_clk_10 = 128'h0;
@@ -1182,7 +1182,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_11[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_11[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_11 = sbox_dout_aes_128_clk_11;
         endcase
     end else begin
         sbox_dout_aes_128_clk_11 = 128'h0;
@@ -1201,7 +1201,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_11[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_11[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_11 = sbox_kout_aes_128_clk_11;
         endcase
     end else begin
         sbox_kout_aes_128_clk_11 = 32'h0;
@@ -1220,7 +1220,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_12[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_12[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_12 = sbox_kout_aes_128_clk_12;
         endcase
     end else begin
         sbox_kout_aes_128_clk_12 = 32'h0;
@@ -1245,7 +1245,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_12[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_12[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_12 = sbox_dout_aes_128_clk_12;
         endcase
     end else begin
         sbox_dout_aes_128_clk_12 = 128'h0;
@@ -1270,7 +1270,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_13[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_13[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_13 = sbox_dout_aes_128_clk_13;
         endcase
     end else begin
         sbox_dout_aes_128_clk_13 = 128'h0;
@@ -1289,7 +1289,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_13[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_13[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_13 = sbox_kout_aes_128_clk_13;
         endcase
     end else begin
         sbox_kout_aes_128_clk_13 = 32'h0;
@@ -1308,7 +1308,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_14[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_14[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_14 = sbox_kout_aes_128_clk_14;
         endcase
     end else begin
         sbox_kout_aes_128_clk_14 = 32'h0;
@@ -1333,7 +1333,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_14[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_14[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_14 = sbox_dout_aes_128_clk_14;
         endcase
     end else begin
         sbox_dout_aes_128_clk_14 = 128'h0;
@@ -1358,7 +1358,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_15[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_15[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_15 = sbox_dout_aes_128_clk_15;
         endcase
     end else begin
         sbox_dout_aes_128_clk_15 = 128'h0;
@@ -1377,7 +1377,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_15[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_15[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_15 = sbox_kout_aes_128_clk_15;
         endcase
     end else begin
         sbox_kout_aes_128_clk_15 = 32'h0;
@@ -1396,7 +1396,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_16[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_16[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_16 = sbox_kout_aes_128_clk_16;
         endcase
     end else begin
         sbox_kout_aes_128_clk_16 = 32'h0;
@@ -1421,7 +1421,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_16[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_16[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_16 = sbox_dout_aes_128_clk_16;
         endcase
     end else begin
         sbox_dout_aes_128_clk_16 = 128'h0;
@@ -1446,7 +1446,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_17[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_17[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_17 = sbox_dout_aes_128_clk_17;
         endcase
     end else begin
         sbox_dout_aes_128_clk_17 = 128'h0;
@@ -1465,7 +1465,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_17[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_17[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_17 = sbox_kout_aes_128_clk_17;
         endcase
     end else begin
         sbox_kout_aes_128_clk_17 = 32'h0;
@@ -1484,7 +1484,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_18[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_18[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_18 = sbox_kout_aes_128_clk_18;
         endcase
     end else begin
         sbox_kout_aes_128_clk_18 = 32'h0;
@@ -1509,7 +1509,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_18[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_18[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_18 = sbox_dout_aes_128_clk_18;
         endcase
     end else begin
         sbox_dout_aes_128_clk_18 = 128'h0;
@@ -1534,7 +1534,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_19[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_19[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_19 = sbox_dout_aes_128_clk_19;
         endcase
     end else begin
         sbox_dout_aes_128_clk_19 = 128'h0;
@@ -1553,7 +1553,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_19[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_19[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_19 = sbox_kout_aes_128_clk_19;
         endcase
     end else begin
         sbox_kout_aes_128_clk_19 = 32'h0;
@@ -1572,7 +1572,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_1a[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_1a[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_1a = sbox_kout_aes_128_clk_1a;
         endcase
     end else begin
         sbox_kout_aes_128_clk_1a = 32'h0;
@@ -1597,7 +1597,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_1a[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_1a[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_1a = sbox_dout_aes_128_clk_1a;
         endcase
     end else begin
         sbox_dout_aes_128_clk_1a = 128'h0;
@@ -1622,7 +1622,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_1b[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_1b[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_1b = sbox_dout_aes_128_clk_1b;
         endcase
     end else begin
         sbox_dout_aes_128_clk_1b = 128'h0;
@@ -1641,7 +1641,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_1b[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_1b[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_1b = sbox_kout_aes_128_clk_1b;
         endcase
     end else begin
         sbox_kout_aes_128_clk_1b = 32'h0;
@@ -1660,7 +1660,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_1c[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_1c[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_1c = sbox_kout_aes_128_clk_1c;
         endcase
     end else begin
         sbox_kout_aes_128_clk_1c = 32'h0;
@@ -1685,7 +1685,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_1c[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_1c[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_1c = sbox_dout_aes_128_clk_1c;
         endcase
     end else begin
         sbox_dout_aes_128_clk_1c = 128'h0;
@@ -1710,7 +1710,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_1d[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_1d[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_1d = sbox_dout_aes_128_clk_1d;
         endcase
     end else begin
         sbox_dout_aes_128_clk_1d = 128'h0;
@@ -1729,7 +1729,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_1d[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_1d[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_1d = sbox_kout_aes_128_clk_1d;
         endcase
     end else begin
         sbox_kout_aes_128_clk_1d = 32'h0;
@@ -1748,7 +1748,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_1e[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_1e[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_1e = sbox_kout_aes_128_clk_1e;
         endcase
     end else begin
         sbox_kout_aes_128_clk_1e = 32'h0;
@@ -1773,7 +1773,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_1e[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_1e[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_1e = sbox_dout_aes_128_clk_1e;
         endcase
     end else begin
         sbox_dout_aes_128_clk_1e = 128'h0;
@@ -1798,7 +1798,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_1f[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_1f[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_1f = sbox_dout_aes_128_clk_1f;
         endcase
     end else begin
         sbox_dout_aes_128_clk_1f = 128'h0;
@@ -1817,7 +1817,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_1f[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_1f[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_1f = sbox_kout_aes_128_clk_1f;
         endcase
     end else begin
         sbox_kout_aes_128_clk_1f = 32'h0;
@@ -1836,7 +1836,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_20[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_20[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_20 = sbox_kout_aes_128_clk_20;
         endcase
     end else begin
         sbox_kout_aes_128_clk_20 = 32'h0;
@@ -1861,7 +1861,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_20[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_20[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_20 = sbox_dout_aes_128_clk_20;
         endcase
     end else begin
         sbox_dout_aes_128_clk_20 = 128'h0;
@@ -1886,7 +1886,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_21[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_21[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_21 = sbox_dout_aes_128_clk_21;
         endcase
     end else begin
         sbox_dout_aes_128_clk_21 = 128'h0;
@@ -1905,7 +1905,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_21[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_21[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_21 = sbox_kout_aes_128_clk_21;
         endcase
     end else begin
         sbox_kout_aes_128_clk_21 = 32'h0;
@@ -1924,7 +1924,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_22[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_22[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_22 = sbox_kout_aes_128_clk_22;
         endcase
     end else begin
         sbox_kout_aes_128_clk_22 = 32'h0;
@@ -1949,7 +1949,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_22[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_22[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_22 = sbox_dout_aes_128_clk_22;
         endcase
     end else begin
         sbox_dout_aes_128_clk_22 = 128'h0;
@@ -1974,7 +1974,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_23[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_23[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_23 = sbox_dout_aes_128_clk_23;
         endcase
     end else begin
         sbox_dout_aes_128_clk_23 = 128'h0;
@@ -1993,7 +1993,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_23[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_23[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_23 = sbox_kout_aes_128_clk_23;
         endcase
     end else begin
         sbox_kout_aes_128_clk_23 = 32'h0;
@@ -2012,7 +2012,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_24[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_24[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_24 = sbox_kout_aes_128_clk_24;
         endcase
     end else begin
         sbox_kout_aes_128_clk_24 = 32'h0;
@@ -2037,7 +2037,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_24[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_24[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_24 = sbox_dout_aes_128_clk_24;
         endcase
     end else begin
         sbox_dout_aes_128_clk_24 = 128'h0;
@@ -2062,7 +2062,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_25[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_25[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_25 = sbox_dout_aes_128_clk_25;
         endcase
     end else begin
         sbox_dout_aes_128_clk_25 = 128'h0;
@@ -2081,7 +2081,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_25[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_25[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_25 = sbox_kout_aes_128_clk_25;
         endcase
     end else begin
         sbox_kout_aes_128_clk_25 = 32'h0;
@@ -2100,7 +2100,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_26[15:8]    = AES_128_out_2;
                 sbox_kout_aes_128_clk_26[7:0]     = AES_128_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_26 = sbox_kout_aes_128_clk_26;
         endcase
     end else begin
         sbox_kout_aes_128_clk_26 = 32'h0;
@@ -2125,7 +2125,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_26[63:56]   = AES_128_out_12;
                 sbox_dout_aes_128_clk_26[55:48]   = AES_128_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_26 = sbox_dout_aes_128_clk_26;
         endcase
     end else begin
         sbox_dout_aes_128_clk_26 = 128'h0;
@@ -2150,7 +2150,7 @@ always @(*) begin
                 sbox_dout_aes_128_clk_27[15:8]    = AES_128_out_8;
                 sbox_dout_aes_128_clk_27[7:0]     = AES_128_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_128_clk_27 = sbox_dout_aes_128_clk_27;
         endcase
     end else begin
         sbox_dout_aes_128_clk_27 = 128'h0;
@@ -2169,7 +2169,7 @@ always @(*) begin
                 sbox_kout_aes_128_clk_27[15:8]    = AES_128_out_12;
                 sbox_kout_aes_128_clk_27[7:0]     = AES_128_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_128_clk_27 = sbox_kout_aes_128_clk_27;
         endcase
     end else begin
         sbox_kout_aes_128_clk_27 = 32'h0;
@@ -2188,7 +2188,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_0[15:8]    = AES_192_out_2;
                 sbox_kout_aes_192_clk_0[7:0]     = AES_192_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_0 = sbox_kout_aes_192_clk_0;
         endcase
     end else begin
         sbox_kout_aes_192_clk_0 = 32'h0;
@@ -2213,7 +2213,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_0[63:56]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_0[55:48]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_0 = sbox_dout_aes_192_clk_0;
         endcase
     end else begin
         sbox_dout_aes_192_clk_0 = 128'h0;
@@ -2238,7 +2238,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_1[127:120] = AES_192_out_12;
                 sbox_dout_aes_192_clk_1[119:112] = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_1 = sbox_dout_aes_192_clk_1;
         endcase
     end else begin
         sbox_dout_aes_192_clk_1 = 128'h0;
@@ -2257,7 +2257,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_1[15:8]    = AES_192_out_10;
                 sbox_kout_aes_192_clk_1[7:0]     = AES_192_out_11;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_1 = sbox_kout_aes_192_clk_1;
         endcase
     end else begin
         sbox_kout_aes_192_clk_1 = 32'h0;
@@ -2286,7 +2286,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_2[31:24]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_2[23:16]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_2 = sbox_dout_aes_192_clk_2;
         endcase
     end else begin
         sbox_dout_aes_192_clk_2 = 128'h0;
@@ -2311,7 +2311,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_3[95:88]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_3[87:80]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_3 = sbox_dout_aes_192_clk_3;
         endcase
     end else begin
         sbox_dout_aes_192_clk_3 = 128'h0;
@@ -2330,7 +2330,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_3[15:8]    = AES_192_out_6;
                 sbox_kout_aes_192_clk_3[7:0]     = AES_192_out_7;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_3 = sbox_kout_aes_192_clk_3;
         endcase
     end else begin
         sbox_kout_aes_192_clk_3 = 32'h0;
@@ -2357,7 +2357,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_4[15:8]    = AES_192_out_10;
                 sbox_dout_aes_192_clk_4[7:0]     = AES_192_out_11;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_4 = sbox_dout_aes_192_clk_4;
         endcase
     end else begin
         sbox_dout_aes_192_clk_4 = 128'h0;
@@ -2374,7 +2374,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_4[31:24]   = AES_192_out_12;
                 sbox_kout_aes_192_clk_4[23:16]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_4 = sbox_kout_aes_192_clk_4;
         endcase
     end else begin
         sbox_kout_aes_192_clk_4 = 32'h0;
@@ -2393,7 +2393,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_5[15:8]    = AES_192_out_2;
                 sbox_kout_aes_192_clk_5[7:0]     = AES_192_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_5 = sbox_kout_aes_192_clk_5;
         endcase
     end else begin
         sbox_kout_aes_192_clk_5 = 32'h0;
@@ -2418,7 +2418,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_5[63:56]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_5[55:48]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_5 = sbox_dout_aes_192_clk_5;
         endcase
     end else begin
         sbox_dout_aes_192_clk_5 = 128'h0;
@@ -2443,7 +2443,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_6[127:120] = AES_192_out_12;
                 sbox_dout_aes_192_clk_6[119:112] = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_6 = sbox_dout_aes_192_clk_6;
         endcase
     end else begin
         sbox_dout_aes_192_clk_6 = 128'h0;
@@ -2462,7 +2462,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_6[15:8]    = AES_192_out_10;
                 sbox_kout_aes_192_clk_6[7:0]     = AES_192_out_11;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_6 = sbox_kout_aes_192_clk_6;
         endcase
     end else begin
         sbox_kout_aes_192_clk_6 = 32'h0;
@@ -2491,7 +2491,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_7[31:24]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_7[23:16]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_7 = sbox_dout_aes_192_clk_7;
         endcase
     end else begin
         sbox_dout_aes_192_clk_7 = 128'h0;
@@ -2516,7 +2516,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_8[95:88]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_8[87:80]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_8 = sbox_dout_aes_192_clk_8;
         endcase
     end else begin
         sbox_dout_aes_192_clk_8 = 128'h0;
@@ -2535,7 +2535,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_8[15:8]    = AES_192_out_6;
                 sbox_kout_aes_192_clk_8[7:0]     = AES_192_out_7;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_8 = sbox_kout_aes_192_clk_8;
         endcase
     end else begin
         sbox_kout_aes_192_clk_8 = 32'h0;
@@ -2562,7 +2562,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_9[15:8]    = AES_192_out_10;
                 sbox_dout_aes_192_clk_9[7:0]     = AES_192_out_11;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_9 = sbox_dout_aes_192_clk_9;
         endcase
     end else begin
         sbox_dout_aes_192_clk_9 = 128'h0;
@@ -2579,7 +2579,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_9[31:24]   = AES_192_out_12;
                 sbox_kout_aes_192_clk_9[23:16]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_9 = sbox_kout_aes_192_clk_9;
         endcase
     end else begin
         sbox_kout_aes_192_clk_9 = 32'h0;
@@ -2598,7 +2598,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_a[15:8]    = AES_192_out_2;
                 sbox_kout_aes_192_clk_a[7:0]     = AES_192_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_a = sbox_kout_aes_192_clk_a;
         endcase
     end else begin
         sbox_kout_aes_192_clk_a = 32'h0;
@@ -2623,7 +2623,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_a[63:56]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_a[55:48]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_a = sbox_dout_aes_192_clk_a;
         endcase
     end else begin
         sbox_dout_aes_192_clk_a = 128'h0;
@@ -2648,7 +2648,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_b[127:120] = AES_192_out_12;
                 sbox_dout_aes_192_clk_b[119:112] = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_b = sbox_dout_aes_192_clk_b;
         endcase
     end else begin
         sbox_dout_aes_192_clk_b = 128'h0;
@@ -2667,7 +2667,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_b[15:8]    = AES_192_out_10;
                 sbox_kout_aes_192_clk_b[7:0]     = AES_192_out_11;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_b = sbox_kout_aes_192_clk_b;
         endcase
     end else begin
         sbox_kout_aes_192_clk_b = 32'h0;
@@ -2696,7 +2696,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_c[31:24]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_c[23:16]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_c = sbox_dout_aes_192_clk_c;
         endcase
     end else begin
         sbox_dout_aes_192_clk_c = 128'h0;
@@ -2721,7 +2721,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_d[95:88]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_d[87:80]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_d = sbox_dout_aes_192_clk_d;
         endcase
     end else begin
         sbox_dout_aes_192_clk_d = 128'h0;
@@ -2740,7 +2740,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_d[15:8]    = AES_192_out_6;
                 sbox_kout_aes_192_clk_d[7:0]     = AES_192_out_7;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_d = sbox_kout_aes_192_clk_d;
         endcase
     end else begin
         sbox_kout_aes_192_clk_d = 32'h0;
@@ -2767,7 +2767,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_e[15:8]    = AES_192_out_10;
                 sbox_dout_aes_192_clk_e[7:0]     = AES_192_out_11;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_e = sbox_dout_aes_192_clk_e;
         endcase
     end else begin
         sbox_dout_aes_192_clk_e = 128'h0;
@@ -2784,7 +2784,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_e[31:24]   = AES_192_out_12;
                 sbox_kout_aes_192_clk_e[23:16]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_e = sbox_kout_aes_192_clk_e;
         endcase
     end else begin
         sbox_kout_aes_192_clk_e = 32'h0;
@@ -2803,7 +2803,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_f[15:8]    = AES_192_out_2;
                 sbox_kout_aes_192_clk_f[7:0]     = AES_192_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_f = sbox_kout_aes_192_clk_f;
         endcase
     end else begin
         sbox_kout_aes_192_clk_f = 32'h0;
@@ -2828,7 +2828,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_f[63:56]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_f[55:48]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_f = sbox_dout_aes_192_clk_f;
         endcase
     end else begin
         sbox_dout_aes_192_clk_f = 128'h0;
@@ -2853,7 +2853,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_10[127:120] = AES_192_out_12;
                 sbox_dout_aes_192_clk_10[119:112] = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_10 = sbox_dout_aes_192_clk_10;
         endcase
     end else begin
         sbox_dout_aes_192_clk_10 = 128'h0;
@@ -2872,7 +2872,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_10[15:8]    = AES_192_out_10;
                 sbox_kout_aes_192_clk_10[7:0]     = AES_192_out_11;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_10 = sbox_kout_aes_192_clk_10;
         endcase
     end else begin
         sbox_kout_aes_192_clk_10 = 32'h0;
@@ -2901,7 +2901,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_11[31:24]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_11[23:16]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_11 = sbox_dout_aes_192_clk_11;
         endcase
     end else begin
         sbox_dout_aes_192_clk_11 = 128'h0;
@@ -2926,7 +2926,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_12[95:88]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_12[87:80]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_12 = sbox_dout_aes_192_clk_12;
         endcase
     end else begin
         sbox_dout_aes_192_clk_12 = 128'h0;
@@ -2945,7 +2945,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_12[15:8]    = AES_192_out_6;
                 sbox_kout_aes_192_clk_12[7:0]     = AES_192_out_7;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_12 = sbox_kout_aes_192_clk_12;
         endcase
     end else begin
         sbox_kout_aes_192_clk_12 = 32'h0;
@@ -2972,7 +2972,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_13[15:8]    = AES_192_out_10;
                 sbox_dout_aes_192_clk_13[7:0]     = AES_192_out_11;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_13 = sbox_dout_aes_192_clk_13;
         endcase
     end else begin
         sbox_dout_aes_192_clk_13 = 128'h0;
@@ -2989,7 +2989,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_13[31:24]   = AES_192_out_12;
                 sbox_kout_aes_192_clk_13[23:16]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_13 = sbox_kout_aes_192_clk_13;
         endcase
     end else begin
         sbox_kout_aes_192_clk_13 = 32'h0;
@@ -3008,7 +3008,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_14[15:8]    = AES_192_out_2;
                 sbox_kout_aes_192_clk_14[7:0]     = AES_192_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_14 = sbox_kout_aes_192_clk_14;
         endcase
     end else begin
         sbox_kout_aes_192_clk_14 = 32'h0;
@@ -3033,7 +3033,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_14[63:56]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_14[55:48]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_14 = sbox_dout_aes_192_clk_14;
         endcase
     end else begin
         sbox_dout_aes_192_clk_14 = 128'h0;
@@ -3058,7 +3058,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_15[127:120] = AES_192_out_12;
                 sbox_dout_aes_192_clk_15[119:112] = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_15 = sbox_dout_aes_192_clk_15;
         endcase
     end else begin
         sbox_dout_aes_192_clk_15 = 128'h0;
@@ -3077,7 +3077,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_15[15:8]    = AES_192_out_10;
                 sbox_kout_aes_192_clk_15[7:0]     = AES_192_out_11;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_15 = sbox_kout_aes_192_clk_15;
         endcase
     end else begin
         sbox_kout_aes_192_clk_15 = 32'h0;
@@ -3106,7 +3106,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_16[31:24]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_16[23:16]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_16 = sbox_dout_aes_192_clk_16;
         endcase
     end else begin
         sbox_dout_aes_192_clk_16 = 128'h0;
@@ -3131,7 +3131,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_17[95:88]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_17[87:80]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_17 = sbox_dout_aes_192_clk_17;
         endcase
     end else begin
         sbox_dout_aes_192_clk_17 = 128'h0;
@@ -3150,7 +3150,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_17[15:8]    = AES_192_out_6;
                 sbox_kout_aes_192_clk_17[7:0]     = AES_192_out_7;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_17 = sbox_kout_aes_192_clk_17;
         endcase
     end else begin
         sbox_kout_aes_192_clk_17 = 32'h0;
@@ -3177,7 +3177,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_18[15:8]    = AES_192_out_10;
                 sbox_dout_aes_192_clk_18[7:0]     = AES_192_out_11;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_18 = sbox_dout_aes_192_clk_18;
         endcase
     end else begin
         sbox_dout_aes_192_clk_18 = 128'h0;
@@ -3194,7 +3194,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_18[31:24]   = AES_192_out_12;
                 sbox_kout_aes_192_clk_18[23:16]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_18 = sbox_kout_aes_192_clk_18;
         endcase
     end else begin
         sbox_kout_aes_192_clk_18 = 32'h0;
@@ -3213,7 +3213,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_19[15:8]    = AES_192_out_2;
                 sbox_kout_aes_192_clk_19[7:0]     = AES_192_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_19 = sbox_kout_aes_192_clk_19;
         endcase
     end else begin
         sbox_kout_aes_192_clk_19 = 32'h0;
@@ -3235,7 +3235,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_19[87:80]   = AES_192_out_9;
                 sbox_dout_aes_192_clk_19[79:72]   = AES_192_out_10;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_19 = sbox_dout_aes_192_clk_19;
         endcase
     end else begin
         sbox_dout_aes_192_clk_19 = 128'h0;
@@ -3260,7 +3260,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_1a[127:120] = AES_192_out_12;
                 sbox_dout_aes_192_clk_1a[119:112] = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_1a = sbox_dout_aes_192_clk_1a;
         endcase
     end else begin
         sbox_dout_aes_192_clk_1a = 128'h0;
@@ -3279,7 +3279,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_1a[15:8]    = AES_192_out_10;
                 sbox_kout_aes_192_clk_1a[7:0]     = AES_192_out_11;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_1a = sbox_kout_aes_192_clk_1a;
         endcase
     end else begin
         sbox_kout_aes_192_clk_1a = 32'h0;
@@ -3308,7 +3308,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_1b[31:24]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_1b[23:16]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_1b = sbox_dout_aes_192_clk_1b;
         endcase
     end else begin
         sbox_dout_aes_192_clk_1b = 128'h0;
@@ -3333,7 +3333,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_1c[95:88]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_1c[87:80]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_1c = sbox_dout_aes_192_clk_1c;
         endcase
     end else begin
         sbox_dout_aes_192_clk_1c = 128'h0;
@@ -3352,7 +3352,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_1c[15:8]    = AES_192_out_6;
                 sbox_kout_aes_192_clk_1c[7:0]     = AES_192_out_7;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_1c = sbox_kout_aes_192_clk_1c;
         endcase
     end else begin
         sbox_kout_aes_192_clk_1c = 32'h0;
@@ -3379,7 +3379,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_1d[15:8]    = AES_192_out_10;
                 sbox_dout_aes_192_clk_1d[7:0]     = AES_192_out_11;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_1d = sbox_dout_aes_192_clk_1d;
         endcase
     end else begin
         sbox_dout_aes_192_clk_1d = 128'h0;
@@ -3396,7 +3396,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_1d[31:24]   = AES_192_out_12;
                 sbox_kout_aes_192_clk_1d[23:16]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_1d = sbox_kout_aes_192_clk_1d;
         endcase
     end else begin
         sbox_kout_aes_192_clk_1d = 32'h0;
@@ -3415,7 +3415,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_1e[15:8]    = AES_192_out_2;
                 sbox_kout_aes_192_clk_1e[7:0]     = AES_192_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_1e = sbox_kout_aes_192_clk_1e;
         endcase
     end else begin
         sbox_kout_aes_192_clk_1e = 32'h0;
@@ -3440,7 +3440,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_1e[63:56]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_1e[55:48]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_1e = sbox_dout_aes_192_clk_1e;
         endcase
     end else begin
         sbox_dout_aes_192_clk_1e = 128'h0;
@@ -3465,7 +3465,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_1f[127:120] = AES_192_out_12;
                 sbox_dout_aes_192_clk_1f[119:112] = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_1f = sbox_dout_aes_192_clk_1f;
         endcase
     end else begin
         sbox_dout_aes_192_clk_1f = 128'h0;
@@ -3484,7 +3484,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_1f[15:8]    = AES_192_out_10;
                 sbox_kout_aes_192_clk_1f[7:0]     = AES_192_out_11;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_1f = sbox_kout_aes_192_clk_1f;
         endcase
     end else begin
         sbox_kout_aes_192_clk_1f = 32'h0;
@@ -3513,7 +3513,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_20[31:24]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_20[23:16]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_20 = sbox_dout_aes_192_clk_20;
         endcase
     end else begin
         sbox_dout_aes_192_clk_20 = 128'h0;
@@ -3538,7 +3538,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_21[95:88]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_21[87:80]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_21 = sbox_dout_aes_192_clk_21;
         endcase
     end else begin
         sbox_dout_aes_192_clk_21 = 128'h0;
@@ -3557,7 +3557,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_21[15:8]    = AES_192_out_6;
                 sbox_kout_aes_192_clk_21[7:0]     = AES_192_out_7;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_21 = sbox_kout_aes_192_clk_21;
         endcase
     end else begin
         sbox_kout_aes_192_clk_21 = 32'h0;
@@ -3584,7 +3584,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_22[15:8]    = AES_192_out_10;
                 sbox_dout_aes_192_clk_22[7:0]     = AES_192_out_11;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_22 = sbox_dout_aes_192_clk_22;
         endcase
     end else begin
         sbox_dout_aes_192_clk_22 = 128'h0;
@@ -3601,7 +3601,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_22[31:24]   = AES_192_out_12;
                 sbox_kout_aes_192_clk_22[23:16]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_22 = sbox_kout_aes_192_clk_22;
         endcase
     end else begin
         sbox_kout_aes_192_clk_22 = 32'h0;
@@ -3620,7 +3620,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_23[15:8]    = AES_192_out_2;
                 sbox_kout_aes_192_clk_23[7:0]     = AES_192_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_23 = sbox_kout_aes_192_clk_23;
         endcase
     end else begin
         sbox_kout_aes_192_clk_23 = 32'h0;
@@ -3645,7 +3645,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_23[63:56]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_23[55:48]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_23 = sbox_dout_aes_192_clk_23;
         endcase
     end else begin
         sbox_dout_aes_192_clk_23 = 128'h0;
@@ -3670,7 +3670,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_24[127:120] = AES_192_out_12;
                 sbox_dout_aes_192_clk_24[119:112] = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_24 = sbox_dout_aes_192_clk_24;
         endcase
     end else begin
         sbox_dout_aes_192_clk_24 = 128'h0;
@@ -3689,7 +3689,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_24[15:8]    = AES_192_out_10;
                 sbox_kout_aes_192_clk_24[7:0]     = AES_192_out_11;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_24 = sbox_kout_aes_192_clk_24;
         endcase
     end else begin
         sbox_kout_aes_192_clk_24 = 32'h0;
@@ -3718,7 +3718,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_25[31:24]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_25[23:16]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_25 = sbox_dout_aes_192_clk_25;
         endcase
     end else begin
         sbox_dout_aes_192_clk_25 = 128'h0;
@@ -3743,7 +3743,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_26[95:88]   = AES_192_out_12;
                 sbox_dout_aes_192_clk_26[87:80]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_26 = sbox_dout_aes_192_clk_26;
         endcase
     end else begin
         sbox_dout_aes_192_clk_26 = 128'h0;
@@ -3762,7 +3762,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_26[15:8]    = AES_192_out_6;
                 sbox_kout_aes_192_clk_26[7:0]     = AES_192_out_7;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_26 = sbox_kout_aes_192_clk_26;
         endcase
     end else begin
         sbox_kout_aes_192_clk_26 = 32'h0;
@@ -3789,7 +3789,7 @@ always @(*) begin
                 sbox_dout_aes_192_clk_27[15:8]    = AES_192_out_10;
                 sbox_dout_aes_192_clk_27[7:0]     = AES_192_out_11;
             end
-            default: ;
+            default: sbox_dout_aes_192_clk_27 = sbox_dout_aes_192_clk_27;
         endcase
     end else begin
         sbox_dout_aes_192_clk_27 = 128'h0;
@@ -3806,7 +3806,7 @@ always @(*) begin
                 sbox_kout_aes_192_clk_27[31:24]   = AES_192_out_12;
                 sbox_kout_aes_192_clk_27[23:16]   = AES_192_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_192_clk_27 = sbox_kout_aes_192_clk_27;
         endcase
     end else begin
         sbox_kout_aes_192_clk_27 = 32'h0;
@@ -3825,7 +3825,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_0[15:8 ]   = AES_256_out_2;
                 sbox_kout_aes_256_clk_0[7:0]     = AES_256_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_0 = sbox_kout_aes_256_clk_0;
         endcase
     end else begin
         sbox_kout_aes_256_clk_0 = 32'h0;
@@ -3850,7 +3850,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_0[63:56]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_0[55:48]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_0 = sbox_dout_aes_256_clk_0;
         endcase
     end else begin
         sbox_dout_aes_256_clk_0 = 128'h0;
@@ -3875,7 +3875,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_1[111:104] = AES_256_out_12;
                 sbox_dout_aes_256_clk_1[103:96]  = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_1 = sbox_dout_aes_256_clk_1;
         endcase
     end else begin
         sbox_dout_aes_256_clk_1 = 128'h0;
@@ -3894,7 +3894,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_1[15:8]    = AES_256_out_8;
                 sbox_kout_aes_256_clk_1[7:0]     = AES_256_out_9;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_1 = sbox_kout_aes_256_clk_1;
         endcase
     end else begin
         sbox_kout_aes_256_clk_1 = 32'h0;
@@ -3921,7 +3921,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_2[15:8]    = AES_256_out_10;
                 sbox_dout_aes_256_clk_2[7:0]     = AES_256_out_11;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_2 = sbox_dout_aes_256_clk_2;
         endcase
     end else begin
         sbox_dout_aes_256_clk_2 = 128'h0;
@@ -3938,7 +3938,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_2[31:24]   = AES_256_out_12;
                 sbox_kout_aes_256_clk_2[23:16]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_2 = sbox_kout_aes_256_clk_2;
         endcase
     end else begin
         sbox_kout_aes_256_clk_2 = 32'h0;
@@ -3955,7 +3955,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_3[15:8]    = AES_256_out_0;
                 sbox_kout_aes_256_clk_3[7:0]     = AES_256_out_1;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_3 = sbox_kout_aes_256_clk_3;
         endcase
     end else begin
         sbox_kout_aes_256_clk_3 = 32'h0;
@@ -3982,7 +3982,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_3[47:40]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_3[39:32]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_3 = sbox_dout_aes_256_clk_3;
         endcase
     end else begin
         sbox_dout_aes_256_clk_3 = 128'h0;
@@ -4007,7 +4007,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_4[95:88]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_4[87:80]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_4 = sbox_dout_aes_256_clk_4;
         endcase
     end else begin
         sbox_dout_aes_256_clk_4 = 128'h0;
@@ -4026,7 +4026,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_4[15:8]    = AES_256_out_6;
                 sbox_kout_aes_256_clk_4[7:0]     = AES_256_out_7;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_4 = sbox_kout_aes_256_clk_4;
         endcase
     end else begin
         sbox_kout_aes_256_clk_4 = 32'h0;
@@ -4051,7 +4051,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_5[15:8]    = AES_256_out_8;
                 sbox_dout_aes_256_clk_5[7:0]     = AES_256_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_5 = sbox_dout_aes_256_clk_5;
         endcase
     end else begin
         sbox_dout_aes_256_clk_5 = 128'h0;
@@ -4070,7 +4070,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_5[15:8]    = AES_256_out_12;
                 sbox_kout_aes_256_clk_5[7:0]     = AES_256_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_5 = sbox_kout_aes_256_clk_5;
         endcase
     end else begin
         sbox_kout_aes_256_clk_5 = 32'h0;
@@ -4099,7 +4099,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_6[31:24]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_6[23:16]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_6 = sbox_dout_aes_256_clk_6;
         endcase
     end else begin
         sbox_dout_aes_256_clk_6 = 128'h0;
@@ -4124,7 +4124,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_7[79:72]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_7[71:64]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_7 = sbox_dout_aes_256_clk_7;
         endcase
     end else begin
         sbox_dout_aes_256_clk_7 = 128'h0;
@@ -4143,7 +4143,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_7[15:8]    = AES_256_out_4;
                 sbox_kout_aes_256_clk_7[7:0]     = AES_256_out_5;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_7 = sbox_kout_aes_256_clk_7;
         endcase
     end else begin
         sbox_kout_aes_256_clk_7 = 32'h0;
@@ -4168,7 +4168,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_8[127:120] = AES_256_out_12;
                 sbox_dout_aes_256_clk_8[119:112] = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_8 = sbox_dout_aes_256_clk_8;
         endcase
     end else begin
         sbox_dout_aes_256_clk_8 = 128'h0;
@@ -4187,7 +4187,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_8[15:8]    = AES_256_out_10;
                 sbox_kout_aes_256_clk_8[7:0]     = AES_256_out_11;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_8 = sbox_kout_aes_256_clk_8;
         endcase
     end else begin
         sbox_kout_aes_256_clk_8 = 32'h0;
@@ -4216,7 +4216,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_9[15:8]    = AES_256_out_12;
                 sbox_dout_aes_256_clk_9[7:0]     = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_9 = sbox_dout_aes_256_clk_9;
         endcase
     end else begin
         sbox_dout_aes_256_clk_9 = 128'h0;
@@ -4235,7 +4235,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_a[15:8 ]   = AES_256_out_2;
                 sbox_kout_aes_256_clk_a[7:0]     = AES_256_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_a = sbox_kout_aes_256_clk_a;
         endcase
     end else begin
         sbox_kout_aes_256_clk_a = 32'h0;
@@ -4260,7 +4260,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_a[63:56]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_a[55:48]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_a = sbox_dout_aes_256_clk_a;
         endcase
     end else begin
         sbox_dout_aes_256_clk_a = 128'h0;
@@ -4285,7 +4285,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_b[111:104] = AES_256_out_12;
                 sbox_dout_aes_256_clk_b[103:96]  = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_b = sbox_dout_aes_256_clk_b;
         endcase
     end else begin
         sbox_dout_aes_256_clk_b = 128'h0;
@@ -4304,7 +4304,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_b[15:8]    = AES_256_out_8;
                 sbox_kout_aes_256_clk_b[7:0]     = AES_256_out_9;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_b = sbox_kout_aes_256_clk_b;
         endcase
     end else begin
         sbox_kout_aes_256_clk_b = 32'h0;
@@ -4331,7 +4331,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_c[15:8]    = AES_256_out_10;
                 sbox_dout_aes_256_clk_c[7:0]     = AES_256_out_11;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_c = sbox_dout_aes_256_clk_c;
         endcase
     end else begin
         sbox_dout_aes_256_clk_c = 128'h0;
@@ -4348,7 +4348,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_c[31:24]   = AES_256_out_12;
                 sbox_kout_aes_256_clk_c[23:16]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_c = sbox_kout_aes_256_clk_c;
         endcase
     end else begin
         sbox_kout_aes_256_clk_c = 32'h0;
@@ -4365,7 +4365,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_d[15:8]    = AES_256_out_0;
                 sbox_kout_aes_256_clk_d[7:0]     = AES_256_out_1;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_d = sbox_kout_aes_256_clk_d;
         endcase
     end else begin
         sbox_kout_aes_256_clk_d = 32'h0;
@@ -4392,7 +4392,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_d[47:40]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_d[39:32]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_d = sbox_dout_aes_256_clk_d;
         endcase
     end else begin
         sbox_dout_aes_256_clk_d = 128'h0;
@@ -4417,7 +4417,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_e[95:88]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_e[87:80]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_e = sbox_dout_aes_256_clk_e;
         endcase
     end else begin
         sbox_dout_aes_256_clk_e = 128'h0;
@@ -4436,7 +4436,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_e[15:8]    = AES_256_out_6;
                 sbox_kout_aes_256_clk_e[7:0]     = AES_256_out_7;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_e = sbox_kout_aes_256_clk_e;
         endcase
     end else begin
         sbox_kout_aes_256_clk_e = 32'h0;
@@ -4461,7 +4461,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_f[15:8]    = AES_256_out_8;
                 sbox_dout_aes_256_clk_f[7:0]     = AES_256_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_f = sbox_dout_aes_256_clk_f;
         endcase
     end else begin
         sbox_dout_aes_256_clk_f = 128'h0;
@@ -4480,7 +4480,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_f[15:8]    = AES_256_out_12;
                 sbox_kout_aes_256_clk_f[7:0]     = AES_256_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_f = sbox_kout_aes_256_clk_f;
         endcase
     end else begin
         sbox_kout_aes_256_clk_f = 32'h0;
@@ -4509,7 +4509,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_10[31:24]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_10[23:16]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_10 = sbox_dout_aes_256_clk_10;
         endcase
     end else begin
         sbox_dout_aes_256_clk_10 = 128'h0;
@@ -4534,7 +4534,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_11[79:72]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_11[71:64]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_11 = sbox_dout_aes_256_clk_11;
         endcase
     end else begin
         sbox_dout_aes_256_clk_11 = 128'h0;
@@ -4553,7 +4553,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_11[15:8]    = AES_256_out_4;
                 sbox_kout_aes_256_clk_11[7:0]     = AES_256_out_5;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_11 = sbox_kout_aes_256_clk_11;
         endcase
     end else begin
         sbox_kout_aes_256_clk_11 = 32'h0;
@@ -4578,7 +4578,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_12[127:120] = AES_256_out_12;
                 sbox_dout_aes_256_clk_12[119:112] = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_12 = sbox_dout_aes_256_clk_12;
         endcase
     end else begin
         sbox_dout_aes_256_clk_12 = 128'h0;
@@ -4597,7 +4597,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_12[15:8]    = AES_256_out_10;
                 sbox_kout_aes_256_clk_12[7:0]     = AES_256_out_11;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_12 = sbox_kout_aes_256_clk_12;
         endcase
     end else begin
         sbox_kout_aes_256_clk_12 = 32'h0;
@@ -4626,7 +4626,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_13[15:8]    = AES_256_out_12;
                 sbox_dout_aes_256_clk_13[7:0]     = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_13 = sbox_dout_aes_256_clk_13;
         endcase
     end else begin
         sbox_dout_aes_256_clk_13 = 128'h0;
@@ -4645,7 +4645,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_14[15:8 ]   = AES_256_out_2;
                 sbox_kout_aes_256_clk_14[7:0]     = AES_256_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_14 = sbox_kout_aes_256_clk_14;
         endcase
     end else begin
         sbox_kout_aes_256_clk_14 = 32'h0;
@@ -4670,7 +4670,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_14[63:56]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_14[55:48]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_14 = sbox_dout_aes_256_clk_14;
         endcase
     end else begin
         sbox_dout_aes_256_clk_14 = 128'h0;
@@ -4695,7 +4695,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_15[111:104] = AES_256_out_12;
                 sbox_dout_aes_256_clk_15[103:96]  = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_15 = sbox_dout_aes_256_clk_15;
         endcase
     end else begin
         sbox_dout_aes_256_clk_15 = 128'h0;
@@ -4714,7 +4714,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_15[15:8]    = AES_256_out_8;
                 sbox_kout_aes_256_clk_15[7:0]     = AES_256_out_9;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_15 = sbox_kout_aes_256_clk_15;
         endcase
     end else begin
         sbox_kout_aes_256_clk_15 = 32'h0;
@@ -4741,7 +4741,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_16[15:8]    = AES_256_out_10;
                 sbox_dout_aes_256_clk_16[7:0]     = AES_256_out_11;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_16 = sbox_dout_aes_256_clk_16;
         endcase
     end else begin
         sbox_dout_aes_256_clk_16 = 128'h0;
@@ -4758,7 +4758,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_16[31:24]   = AES_256_out_12;
                 sbox_kout_aes_256_clk_16[23:16]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_16 = sbox_kout_aes_256_clk_16;
         endcase
     end else begin
         sbox_kout_aes_256_clk_16 = 32'h0;
@@ -4775,7 +4775,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_17[15:8]    = AES_256_out_0;
                 sbox_kout_aes_256_clk_17[7:0]     = AES_256_out_1;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_17 = sbox_kout_aes_256_clk_17;
         endcase
     end else begin
         sbox_kout_aes_256_clk_17 = 32'h0;
@@ -4802,7 +4802,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_17[47:40]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_17[39:32]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_17 = sbox_dout_aes_256_clk_17;
         endcase
     end else begin
         sbox_dout_aes_256_clk_17 = 128'h0;
@@ -4827,7 +4827,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_18[95:88]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_18[87:80]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_18 = sbox_dout_aes_256_clk_18;
         endcase
     end else begin
         sbox_dout_aes_256_clk_18 = 128'h0;
@@ -4846,7 +4846,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_18[15:8]    = AES_256_out_6;
                 sbox_kout_aes_256_clk_18[7:0]     = AES_256_out_7;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_18 = sbox_kout_aes_256_clk_18;
         endcase
     end else begin
         sbox_kout_aes_256_clk_18 = 32'h0;
@@ -4871,7 +4871,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_19[15:8]    = AES_256_out_8;
                 sbox_dout_aes_256_clk_19[7:0]     = AES_256_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_19 = sbox_dout_aes_256_clk_19;
         endcase
     end else begin
         sbox_dout_aes_256_clk_19 = 128'h0;
@@ -4890,7 +4890,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_19[15:8]    = AES_256_out_12;
                 sbox_kout_aes_256_clk_19[7:0]     = AES_256_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_19 = sbox_kout_aes_256_clk_19;
         endcase
     end else begin
         sbox_kout_aes_256_clk_19 = 32'h0;
@@ -4919,7 +4919,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_1a[31:24]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_1a[23:16]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_1a = sbox_dout_aes_256_clk_1a;
         endcase
     end else begin
         sbox_dout_aes_256_clk_1a = 128'h0;
@@ -4944,7 +4944,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_1b[79:72]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_1b[71:64]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_1b = sbox_dout_aes_256_clk_1b;
         endcase
     end else begin
         sbox_dout_aes_256_clk_1b = 128'h0;
@@ -4963,7 +4963,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_1b[15:8]    = AES_256_out_4;
                 sbox_kout_aes_256_clk_1b[7:0]     = AES_256_out_5;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_1b = sbox_kout_aes_256_clk_1b;
         endcase
     end else begin
         sbox_kout_aes_256_clk_1b = 32'h0;
@@ -4988,7 +4988,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_1c[127:120] = AES_256_out_12;
                 sbox_dout_aes_256_clk_1c[119:112] = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_1c = sbox_dout_aes_256_clk_1c;
         endcase
     end else begin
         sbox_dout_aes_256_clk_1c = 128'h0;
@@ -5007,7 +5007,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_1c[15:8]    = AES_256_out_10;
                 sbox_kout_aes_256_clk_1c[7:0]     = AES_256_out_11;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_1c = sbox_kout_aes_256_clk_1c;
         endcase
     end else begin
         sbox_kout_aes_256_clk_1c = 32'h0;
@@ -5036,7 +5036,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_1d[15:8]    = AES_256_out_12;
                 sbox_dout_aes_256_clk_1d[7:0]     = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_1d = sbox_dout_aes_256_clk_1d;
         endcase
     end else begin
         sbox_dout_aes_256_clk_1d = 128'h0;
@@ -5055,7 +5055,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_1e[15:8 ]   = AES_256_out_2;
                 sbox_kout_aes_256_clk_1e[7:0]     = AES_256_out_3;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_1e = sbox_kout_aes_256_clk_1e;
         endcase
     end else begin
         sbox_kout_aes_256_clk_1e = 32'h0;
@@ -5080,7 +5080,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_1e[63:56]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_1e[55:48]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_1e = sbox_dout_aes_256_clk_1e;
         endcase
     end else begin
         sbox_dout_aes_256_clk_1e = 128'h0;
@@ -5105,7 +5105,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_1f[111:104] = AES_256_out_12;
                 sbox_dout_aes_256_clk_1f[103:96]  = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_1f = sbox_dout_aes_256_clk_1f;
         endcase
     end else begin
         sbox_dout_aes_256_clk_1f = 128'h0;
@@ -5124,7 +5124,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_1f[15:8]    = AES_256_out_8;
                 sbox_kout_aes_256_clk_1f[7:0]     = AES_256_out_9;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_1f = sbox_kout_aes_256_clk_1f;
         endcase
     end else begin
         sbox_kout_aes_256_clk_1f = 32'h0;
@@ -5151,7 +5151,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_20[15:8]    = AES_256_out_10;
                 sbox_dout_aes_256_clk_20[7:0]     = AES_256_out_11;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_20 = sbox_dout_aes_256_clk_20;
         endcase
     end else begin
         sbox_dout_aes_256_clk_20 = 128'h0;
@@ -5168,7 +5168,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_20[31:24]   = AES_256_out_12;
                 sbox_kout_aes_256_clk_20[23:16]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_20 = sbox_kout_aes_256_clk_20;
         endcase
     end else begin
         sbox_kout_aes_256_clk_20 = 32'h0;
@@ -5185,7 +5185,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_21[15:8]    = AES_256_out_0;
                 sbox_kout_aes_256_clk_21[7:0]     = AES_256_out_1;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_21 = sbox_kout_aes_256_clk_21;
         endcase
     end else begin
         sbox_kout_aes_256_clk_21 = 32'h0;
@@ -5212,7 +5212,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_21[47:40]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_21[39:32]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_21 = sbox_dout_aes_256_clk_21;
         endcase
     end else begin
         sbox_dout_aes_256_clk_21 = 128'h0;
@@ -5237,7 +5237,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_22[95:88]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_22[87:80]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_22 = sbox_dout_aes_256_clk_22;
         endcase
     end else begin
         sbox_dout_aes_256_clk_22 = 128'h0;
@@ -5256,7 +5256,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_22[15:8]    = AES_256_out_6;
                 sbox_kout_aes_256_clk_22[7:0]     = AES_256_out_7;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_22 = sbox_kout_aes_256_clk_22;
         endcase
     end else begin
         sbox_kout_aes_256_clk_22 = 32'h0;
@@ -5281,7 +5281,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_23[15:8]    = AES_256_out_8;
                 sbox_dout_aes_256_clk_23[7:0]     = AES_256_out_9;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_23 = sbox_dout_aes_256_clk_23;
         endcase
     end else begin
         sbox_dout_aes_256_clk_23 = 128'h0;
@@ -5300,7 +5300,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_23[15:8]    = AES_256_out_12;
                 sbox_kout_aes_256_clk_23[7:0]     = AES_256_out_13;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_23 = sbox_kout_aes_256_clk_23;
         endcase
     end else begin
         sbox_kout_aes_256_clk_23 = 32'h0;
@@ -5329,7 +5329,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_24[31:24]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_24[23:16]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_24 = sbox_dout_aes_256_clk_24;
         endcase
     end else begin
         sbox_dout_aes_256_clk_24 = 128'h0;
@@ -5354,7 +5354,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_25[79:72]   = AES_256_out_12;
                 sbox_dout_aes_256_clk_25[71:64]   = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_25 = sbox_dout_aes_256_clk_25;
         endcase
     end else begin
         sbox_dout_aes_256_clk_25 = 128'h0;
@@ -5373,7 +5373,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_25[15:8]    = AES_256_out_4;
                 sbox_kout_aes_256_clk_25[7:0]     = AES_256_out_5;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_25 = sbox_kout_aes_256_clk_25;
         endcase
     end else begin
         sbox_kout_aes_256_clk_25 = 32'h0;
@@ -5398,7 +5398,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_26[127:120] = AES_256_out_12;
                 sbox_dout_aes_256_clk_26[119:112] = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_26 = sbox_dout_aes_256_clk_26;
         endcase
     end else begin
         sbox_dout_aes_256_clk_26 = 128'h0;
@@ -5417,7 +5417,7 @@ always @(*) begin
                 sbox_kout_aes_256_clk_26[15:8]    = AES_256_out_10;
                 sbox_kout_aes_256_clk_26[7:0]     = AES_256_out_11;
             end
-            default: ;
+            default: sbox_kout_aes_256_clk_26 = sbox_kout_aes_256_clk_26;
         endcase
     end else begin
         sbox_kout_aes_256_clk_26 = 32'h0;
@@ -5446,7 +5446,7 @@ always @(*) begin
                 sbox_dout_aes_256_clk_27[15:8]    = AES_256_out_12;
                 sbox_dout_aes_256_clk_27[7:0]     = AES_256_out_13;
             end
-            default: ;
+            default: sbox_dout_aes_256_clk_27 = sbox_dout_aes_256_clk_27;
         endcase
     end else begin
         sbox_dout_aes_256_clk_27 = 128'h0;
@@ -5467,7 +5467,7 @@ always @(*) begin
                 BK_0_round_0[15:8]  = SM4_out_2;
                 BK_0_round_0[7:0]   = SM4_out_3;
             end
-            default: ;
+            default: BK_0_round_0 = BK_0_round_0;
         endcase
     end
 end
@@ -5486,7 +5486,7 @@ always @(*) begin
                 B_0_round_0[15:8]   = SM4_out_6;
                 B_0_round_0[7:0]    = SM4_out_7;
             end
-            default: ;
+            default: B_0_round_0 = B_0_round_0;
         endcase
     end
 end
@@ -5505,7 +5505,7 @@ always @(*) begin
                 BK_1_round_1[15:8]  = SM4_out_10;
                 BK_1_round_1[7:0]   = SM4_out_11;
             end
-            default: ;
+            default: BK_1_round_1 = BK_1_round_1;
         endcase
     end
 end
@@ -5526,7 +5526,7 @@ always @(*) begin
                 B_1_round_1[15:8]   = SM4_out_1;
                 B_1_round_1[7:0]    = SM4_out_2;
             end
-            default: ;
+            default: B_1_round_1 = B_1_round_1;
         endcase
     end
 end
@@ -5545,7 +5545,7 @@ always @(*) begin
                 BK_0_round_2[15:8]  = SM4_out_5;
                 BK_0_round_2[7:0]   = SM4_out_6;
             end
-            default: ;
+            default: BK_0_round_2 = BK_0_round_2;
         endcase
     end
 end
@@ -5564,7 +5564,7 @@ always @(*) begin
                 B_0_round_2[15:8]   = SM4_out_9;
                 B_0_round_2[7:0]    = SM4_out_10;
             end
-            default: ;
+            default: B_0_round_2 = B_0_round_2;
         endcase
     end
 end
@@ -5585,7 +5585,7 @@ always @(*) begin
                 BK_1_round_3[15:8]  = SM4_out_0;
                 BK_1_round_3[7:0]   = SM4_out_1;
             end
-            default: ;
+            default: BK_1_round_3 = BK_1_round_3;
         endcase
     end
 end
@@ -5604,7 +5604,7 @@ always @(*) begin
                 B_1_round_3[15:8]   = SM4_out_4;
                 B_1_round_3[7:0]    = SM4_out_5;
             end
-            default: ;
+            default: B_1_round_3 = B_1_round_3;
         endcase
     end
 end
@@ -5623,7 +5623,7 @@ always @(*) begin
                 BK_0_round_4[15:8]  = SM4_out_8;
                 BK_0_round_4[7:0]   = SM4_out_9;
             end
-            default: ;
+            default: BK_0_round_4 = BK_0_round_4;
         endcase
     end
 end
@@ -5644,7 +5644,7 @@ always @(*) begin
             6'h3: begin
                 B_0_round_4[7:0]    = SM4_out_0;
             end
-            default: ;
+            default: B_0_round_4 = B_0_round_4;
         endcase
     end
 end
@@ -5663,7 +5663,7 @@ always @(*) begin
                 BK_1_round_5[15:8]  = SM4_out_3;
                 BK_1_round_5[7:0]   = SM4_out_4;
             end
-            default: ;
+            default: BK_1_round_5 = BK_1_round_5;
         endcase
     end
 end
@@ -5682,7 +5682,7 @@ always @(*) begin
                 B_1_round_5[15:8]   = SM4_out_7;
                 B_1_round_5[7:0]    = SM4_out_8;
             end
-            default: ;
+            default: B_1_round_5 = B_1_round_5;
         endcase
     end
 end
@@ -5701,7 +5701,7 @@ always @(*) begin
                 BK_0_round_6[15:8]  = SM4_out_11;
                 BK_0_round_6[7:0]   = SM4_out_12;
             end
-            default: ;
+            default: BK_0_round_6 = BK_0_round_6;
         endcase
     end
 end
@@ -5720,7 +5720,7 @@ always @(*) begin
                 B_0_round_6[15:8]   = SM4_out_2;
                 B_0_round_6[7:0]    = SM4_out_3;
             end
-            default: ;
+            default: B_0_round_6 = B_0_round_6;
         endcase
     end
 end
@@ -5739,7 +5739,7 @@ always @(*) begin
                 BK_1_round_7[15:8]  = SM4_out_6;
                 BK_1_round_7[7:0]   = SM4_out_7;
             end
-            default: ;
+            default: BK_1_round_7 = BK_1_round_7;
         endcase
     end
 end
@@ -5758,7 +5758,7 @@ always @(*) begin
                 B_1_round_7[15:8]   = SM4_out_10;
                 B_1_round_7[7:0]    = SM4_out_11;
             end
-            default: ;
+            default: B_1_round_7 = B_1_round_7;
         endcase
     end
 end
@@ -5779,7 +5779,7 @@ always @(*) begin
                 BK_0_round_8[15:8]  = SM4_out_1;
                 BK_0_round_8[7:0]   = SM4_out_2;
             end
-            default: ;
+            default: BK_0_round_8 = BK_0_round_8;
         endcase
     end
 end
@@ -5798,7 +5798,7 @@ always @(*) begin
                 B_0_round_8[15:8]   = SM4_out_5;
                 B_0_round_8[7:0]    = SM4_out_6;
             end
-            default: ;
+            default: B_0_round_8 = B_0_round_8;
         endcase
     end
 end
@@ -5817,7 +5817,7 @@ always @(*) begin
                 BK_1_round_9[15:8]  = SM4_out_9;
                 BK_1_round_9[7:0]   = SM4_out_10;
             end
-            default: ;
+            default: BK_1_round_9 = BK_1_round_9;
         endcase
     end
 end
@@ -5838,7 +5838,7 @@ always @(*) begin
                 B_1_round_9[15:8]   = SM4_out_0;
                 B_1_round_9[7:0]    = SM4_out_1;
             end
-            default: ;
+            default: B_1_round_9 = B_1_round_9;
         endcase
     end
 end
@@ -5857,7 +5857,7 @@ always @(*) begin
                 BK_0_round_10[15:8] = SM4_out_4;
                 BK_0_round_10[7:0]  = SM4_out_5;
             end
-            default: ;
+            default: BK_0_round_10 = BK_0_round_10;
         endcase
     end
 end
@@ -5876,7 +5876,7 @@ always @(*) begin
                 B_0_round_10[15:8]  = SM4_out_8;
                 B_0_round_10[7:0]   = SM4_out_9;
             end
-            default: ;
+            default: B_0_round_10 = B_0_round_10;
         endcase
     end
 end
@@ -5897,7 +5897,7 @@ always @(*) begin
             6'h7: begin
                 BK_1_round_11[7:0]  = SM4_out_0;
             end
-            default: ;
+            default: BK_1_round_11 = BK_1_round_11;
         endcase
     end
 end
@@ -5916,7 +5916,7 @@ always @(*) begin
                 B_1_round_11[15:8]  = SM4_out_3;
                 B_1_round_11[7:0]   = SM4_out_4;
             end
-            default: ;
+            default: B_1_round_11 = B_1_round_11;
         endcase
     end
 end
@@ -5935,7 +5935,7 @@ always @(*) begin
                 BK_0_round_12[15:8] = SM4_out_7;
                 BK_0_round_12[7:0]  = SM4_out_8;
             end
-            default: ;
+            default: BK_0_round_12 = BK_0_round_12;
         endcase
     end
 end
@@ -5954,7 +5954,7 @@ always @(*) begin
                 B_0_round_12[15:8]  = SM4_out_11;
                 B_0_round_12[7:0]   = SM4_out_12;
             end
-            default: ;
+            default: B_0_round_12 = B_0_round_12;
         endcase
     end
 end
@@ -5973,7 +5973,7 @@ always @(*) begin
                 BK_1_round_13[15:8] = SM4_out_2;
                 BK_1_round_13[7:0]  = SM4_out_3;
             end
-            default: ;
+            default: BK_1_round_13 = BK_1_round_13;
         endcase
     end
 end
@@ -5992,7 +5992,7 @@ always @(*) begin
                 B_1_round_13[15:8]  = SM4_out_6;
                 B_1_round_13[7:0]   = SM4_out_7;
             end
-            default: ;
+            default: B_1_round_13 = B_1_round_13;
         endcase
     end
 end
@@ -6011,7 +6011,7 @@ always @(*) begin
                 BK_0_round_14[15:8] = SM4_out_10;
                 BK_0_round_14[7:0]  = SM4_out_11;
             end
-            default: ;
+            default: BK_0_round_14 = BK_0_round_14;
         endcase
     end
 end
@@ -6032,7 +6032,7 @@ always @(*) begin
                 B_0_round_14[15:8]  = SM4_out_1;
                 B_0_round_14[7:0]   = SM4_out_2;
             end
-            default: ;
+            default: B_0_round_14 = B_0_round_14;
         endcase
     end
 end
@@ -6051,7 +6051,7 @@ always @(*) begin
                 BK_1_round_15[15:8] = SM4_out_5;
                 BK_1_round_15[7:0]  = SM4_out_6;
             end
-            default: ;
+            default: BK_1_round_15 = BK_1_round_15;
         endcase
     end
 end
@@ -6070,7 +6070,7 @@ always @(*) begin
                 B_1_round_15[15:8]  = SM4_out_9;
                 B_1_round_15[7:0]   = SM4_out_10;
             end
-            default: ;
+            default: B_1_round_15 = B_1_round_15;
         endcase
     end
 end
@@ -6091,7 +6091,7 @@ always @(*) begin
                 BK_0_round_16[15:8] = SM4_out_0;
                 BK_0_round_16[7:0]  = SM4_out_1;
             end
-            default: ;
+            default: BK_0_round_16 = BK_0_round_16;
         endcase
     end
 end
@@ -6110,7 +6110,7 @@ always @(*) begin
                 B_0_round_16[15:8]  = SM4_out_4;
                 B_0_round_16[7:0]   = SM4_out_5;
             end
-            default: ;
+            default: B_0_round_16 = B_0_round_16;
         endcase
     end
 end
@@ -6129,7 +6129,7 @@ always @(*) begin
                 BK_1_round_17[15:8] = SM4_out_8;
                 BK_1_round_17[7:0]  = SM4_out_9;
             end
-            default: ;
+            default: BK_1_round_17 = BK_1_round_17;
         endcase
     end
 end
@@ -6150,7 +6150,7 @@ always @(*) begin
             6'hb: begin
                 B_1_round_17[7:0]   = SM4_out_0;
             end
-            default: ;
+            default: B_1_round_17 = B_1_round_17;
         endcase
     end
 end
@@ -6169,7 +6169,7 @@ always @(*) begin
                 BK_0_round_18[15:8] = SM4_out_3;
                 BK_0_round_18[7:0]  = SM4_out_4;
             end
-            default: ;
+            default: BK_0_round_18 = BK_0_round_18;
         endcase
     end
 end
@@ -6188,7 +6188,7 @@ always @(*) begin
                 B_0_round_18[15:8]  = SM4_out_7;
                 B_0_round_18[7:0]   = SM4_out_8;
             end
-            default: ;
+            default: B_0_round_18 = B_0_round_18;
         endcase
     end
 end
@@ -6207,7 +6207,7 @@ always @(*) begin
                 BK_1_round_19[15:8] = SM4_out_11;
                 BK_1_round_19[7:0]  = SM4_out_12;
             end
-            default: ;
+            default: BK_1_round_19 = BK_1_round_19;
         endcase
     end
 end
@@ -6226,7 +6226,7 @@ always @(*) begin
                 B_1_round_19[15:8]  = SM4_out_2;
                 B_1_round_19[7:0]   = SM4_out_3;
             end
-            default: ;
+            default: B_1_round_19 = B_1_round_19;
         endcase
     end
 end
@@ -6245,7 +6245,7 @@ always @(*) begin
                 BK_0_round_20[15:8] = SM4_out_6;
                 BK_0_round_20[7:0]  = SM4_out_7;
             end
-            default: ;
+            default: BK_0_round_20 = BK_0_round_20;
         endcase
     end
 end
@@ -6264,7 +6264,7 @@ always @(*) begin
                 B_0_round_20[15:8]  = SM4_out_10;
                 B_0_round_20[7:0]   = SM4_out_11;
             end
-            default: ;
+            default: B_0_round_20 = B_0_round_20;
         endcase
     end
 end
@@ -6285,7 +6285,7 @@ always @(*) begin
                 BK_1_round_21[15:8] = SM4_out_1;
                 BK_1_round_21[7:0]  = SM4_out_2;
             end
-            default: ;
+            default: BK_1_round_21 = BK_1_round_21;
         endcase
     end
 end
@@ -6304,7 +6304,7 @@ always @(*) begin
                 B_1_round_21[15:8]  = SM4_out_5;
                 B_1_round_21[7:0]   = SM4_out_6;
             end
-            default: ;
+            default: B_1_round_21 = B_1_round_21;
         endcase
     end
 end
@@ -6323,7 +6323,7 @@ always @(*) begin
                 BK_0_round_22[15:8] = SM4_out_9;
                 BK_0_round_22[7:0]  = SM4_out_10;
             end
-            default: ;
+            default: BK_0_round_22 = BK_0_round_22;
         endcase
     end
 end
@@ -6344,7 +6344,7 @@ always @(*) begin
                 B_0_round_22[15:8]  = SM4_out_0;
                 B_0_round_22[7:0]   = SM4_out_1;
             end
-            default: ;
+            default: B_0_round_22 = B_0_round_22;
         endcase
     end
 end
@@ -6363,7 +6363,7 @@ always @(*) begin
                 BK_1_round_23[15:8] = SM4_out_4;
                 BK_1_round_23[7:0]  = SM4_out_5;
             end
-            default: ;
+            default: BK_1_round_23 = BK_1_round_23;
         endcase
     end
 end
@@ -6382,7 +6382,7 @@ always @(*) begin
                 B_1_round_23[15:8]  = SM4_out_8;
                 B_1_round_23[7:0]   = SM4_out_9;
             end
-            default: ;
+            default: B_1_round_23 = B_1_round_23;
         endcase
     end
 end
@@ -6403,7 +6403,7 @@ always @(*) begin
             6'hf: begin
                 BK_0_round_24[7:0]  = SM4_out_0;
             end
-            default: ;
+            default: BK_0_round_24 = BK_0_round_24;
         endcase
     end
 end
@@ -6422,7 +6422,7 @@ always @(*) begin
                 B_0_round_24[15:8]  = SM4_out_3;
                 B_0_round_24[7:0]   = SM4_out_4;
             end
-            default: ;
+            default: B_0_round_24 = B_0_round_24;
         endcase
     end
 end
@@ -6441,7 +6441,7 @@ always @(*) begin
                 BK_1_round_25[15:8] = SM4_out_7;
                 BK_1_round_25[7:0]  = SM4_out_8;
             end
-            default: ;
+            default: BK_1_round_25 = BK_1_round_25;
         endcase
     end
 end
@@ -6460,7 +6460,7 @@ always @(*) begin
                 B_1_round_25[15:8]  = SM4_out_11;
                 B_1_round_25[7:0]   = SM4_out_12;
             end
-            default: ;
+            default: B_1_round_25 = B_1_round_25;
         endcase
     end
 end
@@ -6479,7 +6479,7 @@ always @(*) begin
                 BK_0_round_26[15:8] = SM4_out_2;
                 BK_0_round_26[7:0]  = SM4_out_3;
             end
-            default: ;
+            default: BK_0_round_26 = BK_0_round_26;
         endcase
     end
 end
@@ -6498,7 +6498,7 @@ always @(*) begin
                 B_0_round_26[15:8]  = SM4_out_6;
                 B_0_round_26[7:0]   = SM4_out_7;
             end
-            default: ;
+            default: B_0_round_26 = B_0_round_26;
         endcase
     end
 end
@@ -6517,7 +6517,7 @@ always @(*) begin
                 BK_1_round_27[15:8] = SM4_out_10;
                 BK_1_round_27[7:0]  = SM4_out_11;
             end
-            default: ;
+            default: BK_1_round_27 = BK_1_round_27;
         endcase
     end
 end
@@ -6538,7 +6538,7 @@ always @(*) begin
                 B_1_round_27[15:8]  = SM4_out_1;
                 B_1_round_27[7:0]   = SM4_out_2;
             end
-            default: ;
+            default: B_1_round_27 = B_1_round_27;
         endcase
     end
 end
@@ -6557,7 +6557,7 @@ always @(*) begin
                 BK_0_round_28[15:8] = SM4_out_5;
                 BK_0_round_28[7:0]  = SM4_out_6;
             end
-            default: ;
+            default: BK_0_round_28 = BK_0_round_28;
         endcase
     end
 end
@@ -6576,7 +6576,7 @@ always @(*) begin
                 B_0_round_28[15:8]  = SM4_out_9;
                 B_0_round_28[7:0]   = SM4_out_10;
             end
-            default: ;
+            default: B_0_round_28 = B_0_round_28;
         endcase
     end
 end
@@ -6597,7 +6597,7 @@ always @(*) begin
                 BK_1_round_29[15:8] = SM4_out_0;
                 BK_1_round_29[7:0]  = SM4_out_1;
             end
-            default: ;
+            default: BK_1_round_29 = BK_1_round_29;
         endcase
     end
 end
@@ -6616,7 +6616,7 @@ always @(*) begin
                 B_1_round_29[15:8]  = SM4_out_4;
                 B_1_round_29[7:0]   = SM4_out_5;
             end
-            default: ;
+            default: B_1_round_29 = B_1_round_29;
         endcase
     end
 end
@@ -6635,7 +6635,7 @@ always @(*) begin
                 BK_0_round_30[15:8] = SM4_out_8;
                 BK_0_round_30[7:0]  = SM4_out_9;
             end
-            default: ;
+            default: BK_0_round_30 = BK_0_round_30;
         endcase
     end
 end
@@ -6656,7 +6656,7 @@ always @(*) begin
             6'h13: begin
                 B_0_round_30[7:0]   = SM4_out_0;
             end
-            default: ;
+            default: B_0_round_30 = B_0_round_30;
         endcase
     end
 end
@@ -6675,7 +6675,7 @@ always @(*) begin
                 BK_1_round_31[15:8] = SM4_out_3;
                 BK_1_round_31[7:0]  = SM4_out_4;
             end
-            default: ;
+            default: BK_1_round_31 = BK_1_round_31;
         endcase
     end
 end
@@ -6694,7 +6694,7 @@ always @(*) begin
                 B_1_round_31[15:8]  = SM4_out_7;
                 B_1_round_31[7:0]   = SM4_out_8;
             end
-            default: ;
+            default: B_1_round_31 = B_1_round_31;
         endcase
     end
 end
@@ -6713,7 +6713,7 @@ always @(*) begin
                 BK_0_round_32[15:8] = SM4_out_2;
                 BK_0_round_32[7:0]  = SM4_out_3;
             end
-            default: ;
+            default: BK_0_round_32 = BK_0_round_32;
         endcase
     end
 end
@@ -6732,7 +6732,7 @@ always @(*) begin
                 B_0_round_32[15:8]  = SM4_out_6;
                 B_0_round_32[7:0]   = SM4_out_7;
             end
-            default: ;
+            default: B_0_round_32 = B_0_round_32;
         endcase
     end
 end
@@ -6751,7 +6751,7 @@ always @(*) begin
                 BK_1_round_33[15:8] = SM4_out_10;
                 BK_1_round_33[7:0]  = SM4_out_11;
             end
-            default: ;
+            default: BK_1_round_33 = BK_1_round_33;
         endcase
     end
 end
@@ -6772,7 +6772,7 @@ always @(*) begin
                 B_1_round_33[15:8]  = SM4_out_1;
                 B_1_round_33[7:0]   = SM4_out_2;
             end
-            default: ;
+            default: B_1_round_33 = B_1_round_33;
         endcase
     end
 end
@@ -6791,7 +6791,7 @@ always @(*) begin
                 BK_0_round_34[15:8] = SM4_out_5;
                 BK_0_round_34[7:0]  = SM4_out_6;
             end
-            default: ;
+            default: BK_0_round_34 = BK_0_round_34;
         endcase
     end
 end
@@ -6810,7 +6810,7 @@ always @(*) begin
                 B_0_round_34[15:8]  = SM4_out_9;
                 B_0_round_34[7:0]   = SM4_out_10;
             end
-            default: ;
+            default: B_0_round_34 = B_0_round_34;
         endcase
     end
 end
@@ -6831,7 +6831,7 @@ always @(*) begin
                 BK_1_round_35[15:8] = SM4_out_0;
                 BK_1_round_35[7:0]  = SM4_out_1;
             end
-            default: ;
+            default: BK_1_round_35 = BK_1_round_35;
         endcase
     end
 end
@@ -6850,7 +6850,7 @@ always @(*) begin
                 B_1_round_35[15:8]  = SM4_out_4;
                 B_1_round_35[7:0]   = SM4_out_5;
             end
-            default: ;
+            default: B_1_round_35 = B_1_round_35;
         endcase
     end
 end
@@ -6869,7 +6869,7 @@ always @(*) begin
                 BK_0_round_36[15:8] = SM4_out_8;
                 BK_0_round_36[7:0]  = SM4_out_9;
             end
-            default: ;
+            default: BK_0_round_36 = BK_0_round_36;
         endcase
     end
 end
@@ -6890,7 +6890,7 @@ always @(*) begin
             6'h17: begin
                 B_0_round_36[7:0]   = SM4_out_0;
             end
-            default: ;
+            default: B_0_round_36 = B_0_round_36;
         endcase
     end
 end
@@ -6909,7 +6909,7 @@ always @(*) begin
                 BK_1_round_37[15:8] = SM4_out_3;
                 BK_1_round_37[7:0]  = SM4_out_4;
             end
-            default: ;
+            default: BK_1_round_37 = BK_1_round_37;
         endcase
     end
 end
@@ -6928,7 +6928,7 @@ always @(*) begin
                 B_1_round_37[15:8]  = SM4_out_7;
                 B_1_round_37[7:0]   = SM4_out_8;
             end
-            default: ;
+            default: B_1_round_37 = B_1_round_37;
         endcase
     end
 end
@@ -6947,7 +6947,7 @@ always @(*) begin
                 BK_0_round_38[15:8] = SM4_out_11;
                 BK_0_round_38[7:0]  = SM4_out_12;
             end
-            default: ;
+            default: BK_0_round_38 = BK_0_round_38;
         endcase
     end
 end
@@ -6966,7 +6966,7 @@ always @(*) begin
                 B_0_round_38[15:8]  = SM4_out_2;
                 B_0_round_38[7:0]   = SM4_out_3;
             end
-            default: ;
+            default: B_0_round_38 = B_0_round_38;
         endcase
     end
 end
@@ -6985,7 +6985,7 @@ always @(*) begin
                 BK_1_round_39[15:8] = SM4_out_6;
                 BK_1_round_39[7:0]  = SM4_out_7;
             end
-            default: ;
+            default: BK_1_round_39 = BK_1_round_39;
         endcase
     end
 end
@@ -7004,7 +7004,7 @@ always @(*) begin
                 B_1_round_39[15:8]  = SM4_out_10;
                 B_1_round_39[7:0]   = SM4_out_11;
             end
-            default: ;
+            default: B_1_round_39 = B_1_round_39;
         endcase
     end
 end
@@ -7025,7 +7025,7 @@ always @(*) begin
                 BK_0_round_40[15:8] = SM4_out_1;
                 BK_0_round_40[7:0]  = SM4_out_2;
             end
-            default: ;
+            default: BK_0_round_40 = BK_0_round_40;
         endcase
     end
 end
@@ -7044,7 +7044,7 @@ always @(*) begin
                 B_0_round_40[15:8]  = SM4_out_5;
                 B_0_round_40[7:0]   = SM4_out_6;
             end
-            default: ;
+            default: B_0_round_40 = B_0_round_40;
         endcase
     end
 end
@@ -7063,7 +7063,7 @@ always @(*) begin
                 BK_1_round_41[15:8] = SM4_out_9;
                 BK_1_round_41[7:0]  = SM4_out_10;
             end
-            default: ;
+            default: BK_1_round_41 = BK_1_round_41;
         endcase
     end
 end
@@ -7084,7 +7084,7 @@ always @(*) begin
                 B_1_round_41[15:8]  = SM4_out_0;
                 B_1_round_41[7:0]   = SM4_out_1;
             end
-            default: ;
+            default: B_1_round_41 = B_1_round_41;
         endcase
     end
 end
@@ -7103,7 +7103,7 @@ always @(*) begin
                 BK_0_round_42[15:8] = SM4_out_4;
                 BK_0_round_42[7:0]  = SM4_out_5;
             end
-            default: ;
+            default: BK_0_round_42 = BK_0_round_42;
         endcase
     end
 end
@@ -7122,7 +7122,7 @@ always @(*) begin
                 B_0_round_42[15:8]  = SM4_out_8;
                 B_0_round_42[7:0]   = SM4_out_9;
             end
-            default: ;
+            default: B_0_round_42 = B_0_round_42;
         endcase
     end
 end
@@ -7143,7 +7143,7 @@ always @(*) begin
             6'h1b: begin
                 BK_1_round_43[7:0]  = SM4_out_0;
             end
-            default: ;
+            default: BK_1_round_43 = BK_1_round_43;
         endcase
     end
 end
@@ -7162,7 +7162,7 @@ always @(*) begin
                 B_1_round_43[15:8]  = SM4_out_3;
                 B_1_round_43[7:0]   = SM4_out_4;
             end
-            default: ;
+            default: B_1_round_43 = B_1_round_43;
         endcase
     end
 end
@@ -7181,7 +7181,7 @@ always @(*) begin
                 BK_0_round_44[15:8] = SM4_out_7;
                 BK_0_round_44[7:0]  = SM4_out_8;
             end
-            default: ;
+            default: BK_0_round_44 = BK_0_round_44;
         endcase
     end
 end
@@ -7200,7 +7200,7 @@ always @(*) begin
                 B_0_round_44[15:8]  = SM4_out_11;
                 B_0_round_44[7:0]   = SM4_out_12;
             end
-            default: ;
+            default: B_0_round_44 = B_0_round_44;
         endcase
     end
 end
@@ -7219,7 +7219,7 @@ always @(*) begin
                 BK_1_round_45[15:8] = SM4_out_2;
                 BK_1_round_45[7:0]  = SM4_out_3;
             end
-            default: ;
+            default: BK_1_round_45 = BK_1_round_45;
         endcase
     end
 end
@@ -7238,7 +7238,7 @@ always @(*) begin
                 B_1_round_45[15:8]  = SM4_out_6;
                 B_1_round_45[7:0]   = SM4_out_7;
             end
-            default: ;
+            default: B_1_round_45 = B_1_round_45;
         endcase
     end
 end
@@ -7257,7 +7257,7 @@ always @(*) begin
                 BK_0_round_46[15:8] = SM4_out_10;
                 BK_0_round_46[7:0]  = SM4_out_11;
             end
-            default: ;
+            default: BK_0_round_46 = BK_0_round_46;
         endcase
     end
 end
@@ -7278,7 +7278,7 @@ always @(*) begin
                 B_0_round_46[15:8]  = SM4_out_1;
                 B_0_round_46[7:0]   = SM4_out_2;
             end
-            default: ;
+            default: B_0_round_46 = B_0_round_46;
         endcase
     end
 end
@@ -7297,7 +7297,7 @@ always @(*) begin
                 BK_1_round_47[15:8] = SM4_out_5;
                 BK_1_round_47[7:0]  = SM4_out_6;
             end
-            default: ;
+            default: BK_1_round_47 = BK_1_round_47;
         endcase
     end
 end
@@ -7316,7 +7316,7 @@ always @(*) begin
                 B_1_round_47[15:8]  = SM4_out_9;
                 B_1_round_47[7:0]   = SM4_out_10;
             end
-            default: ;
+            default: B_1_round_47 = B_1_round_47;
         endcase
     end
 end
@@ -7337,7 +7337,7 @@ always @(*) begin
                 BK_0_round_48[15:8] = SM4_out_0;
                 BK_0_round_48[7:0]  = SM4_out_1;
             end
-            default: ;
+            default: BK_0_round_48 = BK_0_round_48;
         endcase
     end
 end
@@ -7356,7 +7356,7 @@ always @(*) begin
                 B_0_round_48[15:8]  = SM4_out_4;
                 B_0_round_48[7:0]   = SM4_out_5;
             end
-            default: ;
+            default: B_0_round_48 = B_0_round_48;
         endcase
     end
 end
@@ -7375,7 +7375,7 @@ always @(*) begin
                 BK_1_round_49[15:8] = SM4_out_8;
                 BK_1_round_49[7:0]  = SM4_out_9;
             end
-            default: ;
+            default: BK_1_round_49 = BK_1_round_49;
         endcase
     end
 end
@@ -7396,7 +7396,7 @@ always @(*) begin
             6'h1f: begin
                 B_1_round_49[7:0]   = SM4_out_0;
             end
-            default: ;
+            default: B_1_round_49 = B_1_round_49;
         endcase
     end
 end
@@ -7415,7 +7415,7 @@ always @(*) begin
                 BK_0_round_50[15:8] = SM4_out_3;
                 BK_0_round_50[7:0]  = SM4_out_4;
             end
-            default: ;
+            default: BK_0_round_50 = BK_0_round_50;
         endcase
     end
 end
@@ -7434,7 +7434,7 @@ always @(*) begin
                 B_0_round_50[15:8]  = SM4_out_7;
                 B_0_round_50[7:0]   = SM4_out_8;
             end
-            default: ;
+            default: B_0_round_50 = B_0_round_50;
         endcase
     end
 end
@@ -7453,7 +7453,7 @@ always @(*) begin
                 BK_1_round_51[15:8] = SM4_out_11;
                 BK_1_round_51[7:0]  = SM4_out_12;
             end
-            default: ;
+            default: BK_1_round_51 = BK_1_round_51;
         endcase
     end
 end
@@ -7472,7 +7472,7 @@ always @(*) begin
                 B_1_round_51[15:8]  = SM4_out_2;
                 B_1_round_51[7:0]   = SM4_out_3;
             end
-            default: ;
+            default: B_1_round_51 = B_1_round_51;
         endcase
     end
 end
@@ -7491,7 +7491,7 @@ always @(*) begin
                 BK_0_round_52[15:8] = SM4_out_6;
                 BK_0_round_52[7:0]  = SM4_out_7;
             end
-            default: ;
+            default: BK_0_round_52 = BK_0_round_52;
         endcase
     end
 end
@@ -7510,7 +7510,7 @@ always @(*) begin
                 B_0_round_52[15:8]  = SM4_out_10;
                 B_0_round_52[7:0]   = SM4_out_11;
             end
-            default: ;
+            default: B_0_round_52 = B_0_round_52;
         endcase
     end
 end
@@ -7531,7 +7531,7 @@ always @(*) begin
                 BK_1_round_53[15:8] = SM4_out_1;
                 BK_1_round_53[7:0]  = SM4_out_2;
             end
-            default: ;
+            default: BK_1_round_53 = BK_1_round_53;
         endcase
     end
 end
@@ -7550,7 +7550,7 @@ always @(*) begin
                 B_1_round_53[15:8]  = SM4_out_5;
                 B_1_round_53[7:0]   = SM4_out_6;
             end
-            default: ;
+            default: B_1_round_53 = B_1_round_53;
         endcase
     end
 end
@@ -7569,7 +7569,7 @@ always @(*) begin
                 BK_0_round_54[15:8] = SM4_out_9;
                 BK_0_round_54[7:0]  = SM4_out_10;
             end
-            default: ;
+            default: BK_0_round_54 = BK_0_round_54;
         endcase
     end
 end
@@ -7590,7 +7590,7 @@ always @(*) begin
                 B_0_round_54[15:8]  = SM4_out_0;
                 B_0_round_54[7:0]   = SM4_out_1;
             end
-            default: ;
+            default: B_0_round_54 = B_0_round_54;
         endcase
     end
 end
@@ -7609,7 +7609,7 @@ always @(*) begin
                 BK_1_round_55[15:8] = SM4_out_4;
                 BK_1_round_55[7:0]  = SM4_out_5;
             end
-            default: ;
+            default: BK_1_round_55 = BK_1_round_55;
         endcase
     end
 end
@@ -7628,7 +7628,7 @@ always @(*) begin
                 B_1_round_55[15:8]  = SM4_out_8;
                 B_1_round_55[7:0]   = SM4_out_9;
             end
-            default: ;
+            default: B_1_round_55 = B_1_round_55;
         endcase
     end
 end
@@ -7649,7 +7649,7 @@ always @(*) begin
             6'h23: begin
                 BK_0_round_56[7:0]  = SM4_out_0;
             end
-            default: ;
+            default: BK_0_round_56 = BK_0_round_56;
         endcase
     end
 end
@@ -7668,7 +7668,7 @@ always @(*) begin
                 B_0_round_56[15:8]  = SM4_out_3;
                 B_0_round_56[7:0]   = SM4_out_4;
             end
-            default: ;
+            default: B_0_round_56 = B_0_round_56;
         endcase
     end
 end
@@ -7687,7 +7687,7 @@ always @(*) begin
                 BK_1_round_57[15:8] = SM4_out_7;
                 BK_1_round_57[7:0]  = SM4_out_8;
             end
-            default: ;
+            default: BK_1_round_57 = BK_1_round_57;
         endcase
     end
 end
@@ -7706,7 +7706,7 @@ always @(*) begin
                 B_1_round_57[15:8]  = SM4_out_11;
                 B_1_round_57[7:0]   = SM4_out_12;
             end
-            default: ;
+            default: B_1_round_57 = B_1_round_57;
         endcase
     end
 end
@@ -7725,7 +7725,7 @@ always @(*) begin
                 BK_0_round_58[15:8] = SM4_out_2;
                 BK_0_round_58[7:0]  = SM4_out_3;
             end
-            default: ;
+            default: BK_0_round_58 = BK_0_round_58;
         endcase
     end
 end
@@ -7744,7 +7744,7 @@ always @(*) begin
                 B_0_round_58[15:8]  = SM4_out_6;
                 B_0_round_58[7:0]   = SM4_out_7;
             end
-            default: ;
+            default: B_0_round_58 = B_0_round_58;
         endcase
     end
 end
@@ -7763,7 +7763,7 @@ always @(*) begin
                 BK_1_round_59[15:8] = SM4_out_10;
                 BK_1_round_59[7:0]  = SM4_out_11;
             end
-            default: ;
+            default: BK_1_round_59 = BK_1_round_59;
         endcase
     end
 end
@@ -7784,7 +7784,7 @@ always @(*) begin
                 B_1_round_59[15:8]  = SM4_out_1;
                 B_1_round_59[7:0]   = SM4_out_2;
             end
-            default: ;
+            default: B_1_round_59 = B_1_round_59;
         endcase
     end
 end
@@ -7803,7 +7803,7 @@ always @(*) begin
                 BK_0_round_60[15:8] = SM4_out_5;
                 BK_0_round_60[7:0]  = SM4_out_6;
             end
-            default: ;
+            default: BK_0_round_60 = BK_0_round_60;
         endcase
     end
 end
@@ -7822,7 +7822,7 @@ always @(*) begin
                 B_0_round_60[15:8]  = SM4_out_9;
                 B_0_round_60[7:0]   = SM4_out_10;
             end
-            default: ;
+            default: B_0_round_60 = B_0_round_60;
         endcase
     end
 end
@@ -7843,7 +7843,7 @@ always @(*) begin
                 BK_1_round_61[15:8] = SM4_out_0;
                 BK_1_round_61[7:0]  = SM4_out_1;
             end
-            default: ;
+            default: BK_1_round_61 = BK_1_round_61;
         endcase
     end
 end
@@ -7862,7 +7862,7 @@ always @(*) begin
                 B_1_round_61[15:8]  = SM4_out_4;
                 B_1_round_61[7:0]   = SM4_out_5;
             end
-            default: ;
+            default: B_1_round_61 = B_1_round_61;
         endcase
     end
 end
@@ -7881,7 +7881,7 @@ always @(*) begin
                 BK_0_round_62[15:8] = SM4_out_8;
                 BK_0_round_62[7:0]  = SM4_out_9;
             end
-            default: ;
+            default: BK_0_round_62 = BK_0_round_62;
         endcase
     end
 end
@@ -7902,7 +7902,7 @@ always @(*) begin
             6'h27: begin
                 B_0_round_62[7:0]   = SM4_out_0;
             end
-            default: ;
+            default: B_0_round_62 = B_0_round_62;
         endcase
     end
 end
@@ -7921,7 +7921,7 @@ always @(*) begin
                 BK_1_round_63[15:8] = SM4_out_3;
                 BK_1_round_63[7:0]  = SM4_out_4;
             end
-            default: ;
+            default: BK_1_round_63 = BK_1_round_63;
         endcase
     end
 end
@@ -7940,7 +7940,7 @@ always @(*) begin
                 B_1_round_63[15:8]  = SM4_out_7;
                 B_1_round_63[7:0]   = SM4_out_8;
             end
-            default: ;
+            default: B_1_round_63 = B_1_round_63;
         endcase
     end
 end
@@ -7951,7 +7951,7 @@ always @(*) begin
     end else if (cfg[2:1] == 2'b01) begin
         sbox_kout_aes_192_clk_2 = 32'h0;
         case (clk_cnt_all)
-            default: ;
+            default: sbox_kout_aes_192_clk_2 = sbox_kout_aes_192_clk_2;
         endcase
     end else begin
         sbox_kout_aes_192_clk_2 = 32'h0;
@@ -7964,7 +7964,7 @@ always @(*) begin
     end else if (cfg[2:1] == 2'b01) begin
         sbox_kout_aes_192_clk_7 = 32'h0;
         case (clk_cnt_all)
-            default: ;
+            default: sbox_kout_aes_192_clk_7 = sbox_kout_aes_192_clk_7;
         endcase
     end else begin
         sbox_kout_aes_192_clk_7 = 32'h0;
@@ -7977,7 +7977,7 @@ always @(*) begin
     end else if (cfg[2:1] == 2'b01) begin
         sbox_kout_aes_192_clk_c = 32'h0;
         case (clk_cnt_all)
-            default: ;
+            default: sbox_kout_aes_192_clk_c = sbox_kout_aes_192_clk_c;
         endcase
     end else begin
         sbox_kout_aes_192_clk_c = 32'h0;
@@ -7990,7 +7990,7 @@ always @(*) begin
     end else if (cfg[2:1] == 2'b01) begin
         sbox_kout_aes_192_clk_11 = 32'h0;
         case (clk_cnt_all)
-            default: ;
+            default: sbox_kout_aes_192_clk_11 = sbox_kout_aes_192_clk_11;
         endcase
     end else begin
         sbox_kout_aes_192_clk_11 = 32'h0;
@@ -8003,7 +8003,7 @@ always @(*) begin
     end else if (cfg[2:1] == 2'b01) begin
         sbox_kout_aes_192_clk_16 = 32'h0;
         case (clk_cnt_all)
-            default: ;
+            default: sbox_kout_aes_192_clk_16 = sbox_kout_aes_192_clk_16;
         endcase
     end else begin
         sbox_kout_aes_192_clk_16 = 32'h0;
@@ -8016,7 +8016,7 @@ always @(*) begin
     end else if (cfg[2:1] == 2'b01) begin
         sbox_kout_aes_192_clk_1b = 32'h0;
         case (clk_cnt_all)
-            default: ;
+            default: sbox_kout_aes_192_clk_1b = sbox_kout_aes_192_clk_1b;
         endcase
     end else begin
         sbox_kout_aes_192_clk_1b = 32'h0;
@@ -8029,7 +8029,7 @@ always @(*) begin
     end else if (cfg[2:1] == 2'b01) begin
         sbox_kout_aes_192_clk_20 = 32'h0;
         case (clk_cnt_all)
-            default: ;
+            default: sbox_kout_aes_192_clk_20 = sbox_kout_aes_192_clk_20;
         endcase
     end else begin
         sbox_kout_aes_192_clk_20 = 32'h0;
@@ -8042,7 +8042,7 @@ always @(*) begin
     end else if (cfg[2:1] == 2'b01) begin
         sbox_kout_aes_192_clk_25 = 32'h0;
         case (clk_cnt_all)
-            default: ;
+            default: sbox_kout_aes_192_clk_25 = sbox_kout_aes_192_clk_25;
         endcase
     end else begin
         sbox_kout_aes_192_clk_25 = 32'h0;
@@ -8055,7 +8055,7 @@ always @(*) begin
     end else if (cfg[2:1] == 2'b10) begin
         sbox_kout_aes_256_clk_6 = 32'h0;
         case (clk_cnt_all)
-            default: ;
+            default: sbox_kout_aes_256_clk_6 = sbox_kout_aes_256_clk_6;
         endcase
     end else begin
         sbox_kout_aes_256_clk_6 = 32'h0;
@@ -8068,7 +8068,7 @@ always @(*) begin
     end else if (cfg[2:1] == 2'b10) begin
         sbox_kout_aes_256_clk_9 = 32'h0;
         case (clk_cnt_all)
-            default: ;
+            default: sbox_kout_aes_256_clk_9 = sbox_kout_aes_256_clk_9;
         endcase
     end else begin
         sbox_kout_aes_256_clk_9 = 32'h0;
@@ -8081,7 +8081,7 @@ always @(*) begin
     end else if (cfg[2:1] == 2'b10) begin
         sbox_kout_aes_256_clk_10 = 32'h0;
         case (clk_cnt_all)
-            default: ;
+            default: sbox_kout_aes_256_clk_10 = sbox_kout_aes_256_clk_10;
         endcase
     end else begin
         sbox_kout_aes_256_clk_10 = 32'h0;
@@ -8094,7 +8094,7 @@ always @(*) begin
     end else if (cfg[2:1] == 2'b10) begin
         sbox_kout_aes_256_clk_13 = 32'h0;
         case (clk_cnt_all)
-            default: ;
+            default: sbox_kout_aes_256_clk_13 = sbox_kout_aes_256_clk_13;
         endcase
     end else begin
         sbox_kout_aes_256_clk_13 = 32'h0;
@@ -8107,7 +8107,7 @@ always @(*) begin
     end else if (cfg[2:1] == 2'b10) begin
         sbox_kout_aes_256_clk_1a = 32'h0;
         case (clk_cnt_all)
-            default: ;
+            default: sbox_kout_aes_256_clk_1a = sbox_kout_aes_256_clk_1a;
         endcase
     end else begin
         sbox_kout_aes_256_clk_1a = 32'h0;
@@ -8120,7 +8120,7 @@ always @(*) begin
     end else if (cfg[2:1] == 2'b10) begin
         sbox_kout_aes_256_clk_1d = 32'h0;
         case (clk_cnt_all)
-            default: ;
+            default: sbox_kout_aes_256_clk_1d = sbox_kout_aes_256_clk_1d;
         endcase
     end else begin
         sbox_kout_aes_256_clk_1d = 32'h0;
@@ -8133,7 +8133,7 @@ always @(*) begin
     end else if (cfg[2:1] == 2'b10) begin
         sbox_kout_aes_256_clk_24 = 32'h0;
         case (clk_cnt_all)
-            default: ;
+            default: sbox_kout_aes_256_clk_24 = sbox_kout_aes_256_clk_24;
         endcase
     end else begin
         sbox_kout_aes_256_clk_24 = 32'h0;
@@ -8146,7 +8146,7 @@ always @(*) begin
     end else if (cfg[2:1] == 2'b10) begin
         sbox_kout_aes_256_clk_27 = 32'h0;
         case (clk_cnt_all)
-            default: ;
+            default: sbox_kout_aes_256_clk_27 = sbox_kout_aes_256_clk_27;
         endcase
     end else begin
         sbox_kout_aes_256_clk_27 = 32'h0;


### PR DESCRIPTION
## Summary
- Replace all `default: ;` case branches with self-assignments to prevent unintended latching

## Testing
- `verilator --lint-only rca.v` *(failed: command not found)*
- `apt-get install -y verilator`
- `verilator --lint-only --Wall --Wno-CASEINCOMPLETE --Wno-UNUSEDSIGNAL rca.v`

------
https://chatgpt.com/codex/tasks/task_e_689564d1172c832296793786fb6731e0