### PR TITLE
refactor: simplify always blocks

### DIFF
--- a/test.v
+++ b/test.v
@@ -1,10 +1,5 @@
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_0 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_0 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h0: begin
                 BK_0_round_0[31:24] = SM4_out_0;
@@ -12,17 +7,11 @@ always @(*) begin
                 BK_0_round_0[15:8]  = SM4_out_2;
                 BK_0_round_0[7:0]   = SM4_out_3;
             end
-            default: BK_0_round_0 = BK_0_round_0;
+            default: BK_0_round_0 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_0 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_0 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h0: begin
                 B_0_round_0[31:24]  = SM4_out_4;
@@ -30,17 +19,11 @@ always @(*) begin
                 B_0_round_0[15:8]   = SM4_out_6;
                 B_0_round_0[7:0]    = SM4_out_7;
             end
-            default: B_0_round_0 = B_0_round_0;
+            default: B_0_round_0 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_1 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_1 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h0: begin
                 BK_1_round_1[31:24] = SM4_out_8;
@@ -48,17 +31,11 @@ always @(*) begin
                 BK_1_round_1[15:8]  = SM4_out_10;
                 BK_1_round_1[7:0]   = SM4_out_11;
             end
-            default: BK_1_round_1 = BK_1_round_1;
+            default: BK_1_round_1 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_1 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_1 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h0: begin
                 B_1_round_1[31:24]  = SM4_out_12;
@@ -68,9 +45,8 @@ always @(*) begin
                 B_1_round_1[15:8]   = SM4_out_1;
                 B_1_round_1[7:0]    = SM4_out_2;
             end
-            default: B_1_round_1 = B_1_round_1;
+            default: B_1_round_1 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
@@ -86,11 +62,6 @@ always @(*) begin
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_2 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_2 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1: begin
                 B_0_round_2[31:24]  = SM4_out_7;
@@ -98,17 +69,11 @@ always @(*) begin
                 B_0_round_2[15:8]   = SM4_out_9;
                 B_0_round_2[7:0]    = SM4_out_10;
             end
-            default: B_0_round_2 = B_0_round_2;
+            default: B_0_round_2 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_3 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_3 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1: begin
                 BK_1_round_3[31:24] = SM4_out_11;
@@ -118,17 +83,11 @@ always @(*) begin
                 BK_1_round_3[15:8]  = SM4_out_0;
                 BK_1_round_3[7:0]   = SM4_out_1;
             end
-            default: BK_1_round_3 = BK_1_round_3;
+            default: BK_1_round_3 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_3 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_3 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h2: begin
                 B_1_round_3[31:24]  = SM4_out_2;
@@ -136,17 +95,11 @@ always @(*) begin
                 B_1_round_3[15:8]   = SM4_out_4;
                 B_1_round_3[7:0]    = SM4_out_5;
             end
-            default: B_1_round_3 = B_1_round_3;
+            default: B_1_round_3 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_4 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_4 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h2: begin
                 BK_0_round_4[31:24] = SM4_out_6;
@@ -154,17 +107,11 @@ always @(*) begin
                 BK_0_round_4[15:8]  = SM4_out_8;
                 BK_0_round_4[7:0]   = SM4_out_9;
             end
-            default: BK_0_round_4 = BK_0_round_4;
+            default: BK_0_round_4 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_4 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_4 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h2: begin
                 B_0_round_4[31:24]  = SM4_out_10;
@@ -174,17 +121,11 @@ always @(*) begin
             6'h3: begin
                 B_0_round_4[7:0]    = SM4_out_0;
             end
-            default: B_0_round_4 = B_0_round_4;
+            default: B_0_round_4 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_5 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_5 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h3: begin
                 BK_1_round_5[31:24] = SM4_out_1;
@@ -192,17 +133,11 @@ always @(*) begin
                 BK_1_round_5[15:8]  = SM4_out_3;
                 BK_1_round_5[7:0]   = SM4_out_4;
             end
-            default: BK_1_round_5 = BK_1_round_5;
+            default: BK_1_round_5 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_5 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_5 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h3: begin
                 B_1_round_5[31:24]  = SM4_out_5;
@@ -210,17 +145,11 @@ always @(*) begin
                 B_1_round_5[15:8]   = SM4_out_7;
                 B_1_round_5[7:0]    = SM4_out_8;
             end
-            default: B_1_round_5 = B_1_round_5;
+            default: B_1_round_5 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_6 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_6 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h3: begin
                 BK_0_round_6[31:24] = SM4_out_9;
@@ -228,17 +157,11 @@ always @(*) begin
                 BK_0_round_6[15:8]  = SM4_out_11;
                 BK_0_round_6[7:0]   = SM4_out_12;
             end
-            default: BK_0_round_6 = BK_0_round_6;
+            default: BK_0_round_6 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_6 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_6 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h4: begin
                 B_0_round_6[31:24]  = SM4_out_0;
@@ -246,17 +169,11 @@ always @(*) begin
                 B_0_round_6[15:8]   = SM4_out_2;
                 B_0_round_6[7:0]    = SM4_out_3;
             end
-            default: B_0_round_6 = B_0_round_6;
+            default: B_0_round_6 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_7 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_7 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h4: begin
                 BK_1_round_7[31:24] = SM4_out_4;
@@ -264,17 +181,11 @@ always @(*) begin
                 BK_1_round_7[15:8]  = SM4_out_6;
                 BK_1_round_7[7:0]   = SM4_out_7;
             end
-            default: BK_1_round_7 = BK_1_round_7;
+            default: BK_1_round_7 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_7 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_7 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h4: begin
                 B_1_round_7[31:24]  = SM4_out_8;
@@ -282,17 +193,11 @@ always @(*) begin
                 B_1_round_7[15:8]   = SM4_out_10;
                 B_1_round_7[7:0]    = SM4_out_11;
             end
-            default: B_1_round_7 = B_1_round_7;
+            default: B_1_round_7 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_8 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_8 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h4: begin
                 BK_0_round_8[31:24] = SM4_out_12;
@@ -302,17 +207,11 @@ always @(*) begin
                 BK_0_round_8[15:8]  = SM4_out_1;
                 BK_0_round_8[7:0]   = SM4_out_2;
             end
-            default: BK_0_round_8 = BK_0_round_8;
+            default: BK_0_round_8 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_8 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_8 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h5: begin
                 B_0_round_8[31:24]  = SM4_out_3;
@@ -320,17 +219,11 @@ always @(*) begin
                 B_0_round_8[15:8]   = SM4_out_5;
                 B_0_round_8[7:0]    = SM4_out_6;
             end
-            default: B_0_round_8 = B_0_round_8;
+            default: B_0_round_8 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_9 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_9 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h5: begin
                 BK_1_round_9[31:24] = SM4_out_7;
@@ -338,17 +231,11 @@ always @(*) begin
                 BK_1_round_9[15:8]  = SM4_out_9;
                 BK_1_round_9[7:0]   = SM4_out_10;
             end
-            default: BK_1_round_9 = BK_1_round_9;
+            default: BK_1_round_9 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_9 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_9 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h5: begin
                 B_1_round_9[31:24]  = SM4_out_11;
@@ -358,17 +245,11 @@ always @(*) begin
                 B_1_round_9[15:8]   = SM4_out_0;
                 B_1_round_9[7:0]    = SM4_out_1;
             end
-            default: B_1_round_9 = B_1_round_9;
+            default: B_1_round_9 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_10 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_10 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h6: begin
                 BK_0_round_10[31:24]= SM4_out_2;
@@ -376,17 +257,11 @@ always @(*) begin
                 BK_0_round_10[15:8] = SM4_out_4;
                 BK_0_round_10[7:0]  = SM4_out_5;
             end
-            default: BK_0_round_10 = BK_0_round_10;
+            default: BK_0_round_10 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_10 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_10 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h6: begin
                 B_0_round_10[31:24] = SM4_out_6;
@@ -394,17 +269,11 @@ always @(*) begin
                 B_0_round_10[15:8]  = SM4_out_8;
                 B_0_round_10[7:0]   = SM4_out_9;
             end
-            default: B_0_round_10 = B_0_round_10;
+            default: B_0_round_10 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_11 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_11 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h6: begin
                 BK_1_round_11[31:24]= SM4_out_10;
@@ -414,17 +283,11 @@ always @(*) begin
             6'h7: begin
                 BK_1_round_11[7:0]  = SM4_out_0;
             end
-            default: BK_1_round_11 = BK_1_round_11;
+            default: BK_1_round_11 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_11 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_11 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h7: begin
                 B_1_round_11[31:24] = SM4_out_1;
@@ -432,17 +295,11 @@ always @(*) begin
                 B_1_round_11[15:8]  = SM4_out_3;
                 B_1_round_11[7:0]   = SM4_out_4;
             end
-            default: B_1_round_11 = B_1_round_11;
+            default: B_1_round_11 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_12 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_12 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h7: begin
                 BK_0_round_12[31:24]= SM4_out_5;
@@ -450,17 +307,11 @@ always @(*) begin
                 BK_0_round_12[15:8] = SM4_out_7;
                 BK_0_round_12[7:0]  = SM4_out_8;
             end
-            default: BK_0_round_12 = BK_0_round_12;
+            default: BK_0_round_12 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_12 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_12 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h7: begin
                 B_0_round_12[31:24] = SM4_out_9;
@@ -468,17 +319,11 @@ always @(*) begin
                 B_0_round_12[15:8]  = SM4_out_11;
                 B_0_round_12[7:0]   = SM4_out_12;
             end
-            default: B_0_round_12 = B_0_round_12;
+            default: B_0_round_12 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_13 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_13 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h8: begin
                 BK_1_round_13[31:24]= SM4_out_0;
@@ -486,17 +331,11 @@ always @(*) begin
                 BK_1_round_13[15:8] = SM4_out_2;
                 BK_1_round_13[7:0]  = SM4_out_3;
             end
-            default: BK_1_round_13 = BK_1_round_13;
+            default: BK_1_round_13 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_13 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_13 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h8: begin
                 B_1_round_13[31:24] = SM4_out_4;
@@ -504,17 +343,11 @@ always @(*) begin
                 B_1_round_13[15:8]  = SM4_out_6;
                 B_1_round_13[7:0]   = SM4_out_7;
             end
-            default: B_1_round_13 = B_1_round_13;
+            default: B_1_round_13 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_14 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_14 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h8: begin
                 BK_0_round_14[31:24]= SM4_out_8;
@@ -522,17 +355,11 @@ always @(*) begin
                 BK_0_round_14[15:8] = SM4_out_10;
                 BK_0_round_14[7:0]  = SM4_out_11;
             end
-            default: BK_0_round_14 = BK_0_round_14;
+            default: BK_0_round_14 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_14 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_14 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h8: begin
                 B_0_round_14[31:24] = SM4_out_12;
@@ -542,17 +369,11 @@ always @(*) begin
                 B_0_round_14[15:8]  = SM4_out_1;
                 B_0_round_14[7:0]   = SM4_out_2;
             end
-            default: B_0_round_14 = B_0_round_14;
+            default: B_0_round_14 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_15 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_15 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h9: begin
                 BK_1_round_15[31:24]= SM4_out_3;
@@ -560,17 +381,11 @@ always @(*) begin
                 BK_1_round_15[15:8] = SM4_out_5;
                 BK_1_round_15[7:0]  = SM4_out_6;
             end
-            default: BK_1_round_15 = BK_1_round_15;
+            default: BK_1_round_15 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_15 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_15 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h9: begin
                 B_1_round_15[31:24] = SM4_out_7;
@@ -578,17 +393,11 @@ always @(*) begin
                 B_1_round_15[15:8]  = SM4_out_9;
                 B_1_round_15[7:0]   = SM4_out_10;
             end
-            default: B_1_round_15 = B_1_round_15;
+            default: B_1_round_15 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_16 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_16 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h9: begin
                 BK_0_round_16[31:24]= SM4_out_11;
@@ -598,17 +407,11 @@ always @(*) begin
                 BK_0_round_16[15:8] = SM4_out_0;
                 BK_0_round_16[7:0]  = SM4_out_1;
             end
-            default: BK_0_round_16 = BK_0_round_16;
+            default: BK_0_round_16 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_16 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_16 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'ha: begin
                 B_0_round_16[31:24] = SM4_out_2;
@@ -616,17 +419,11 @@ always @(*) begin
                 B_0_round_16[15:8]  = SM4_out_4;
                 B_0_round_16[7:0]   = SM4_out_5;
             end
-            default: B_0_round_16 = B_0_round_16;
+            default: B_0_round_16 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_17 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_17 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'ha: begin
                 BK_1_round_17[31:24]= SM4_out_6;
@@ -634,17 +431,11 @@ always @(*) begin
                 BK_1_round_17[15:8] = SM4_out_8;
                 BK_1_round_17[7:0]  = SM4_out_9;
             end
-            default: BK_1_round_17 = BK_1_round_17;
+            default: BK_1_round_17 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_17 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_17 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'ha: begin
                 B_1_round_17[31:24] = SM4_out_10;
@@ -654,17 +445,11 @@ always @(*) begin
             6'hb: begin
                 B_1_round_17[7:0]   = SM4_out_0;
             end
-            default: B_1_round_17 = B_1_round_17;
+            default: B_1_round_17 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_18 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_18 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'hb: begin
                 BK_0_round_18[31:24]= SM4_out_1;
@@ -672,17 +457,11 @@ always @(*) begin
                 BK_0_round_18[15:8] = SM4_out_3;
                 BK_0_round_18[7:0]  = SM4_out_4;
             end
-            default: BK_0_round_18 = BK_0_round_18;
+            default: BK_0_round_18 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_18 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_18 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'hb: begin
                 B_0_round_18[31:24] = SM4_out_5;
@@ -690,17 +469,11 @@ always @(*) begin
                 B_0_round_18[15:8]  = SM4_out_7;
                 B_0_round_18[7:0]   = SM4_out_8;
             end
-            default: B_0_round_18 = B_0_round_18;
+            default: B_0_round_18 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_19 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_19 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'hb: begin
                 BK_1_round_19[31:24]= SM4_out_9;
@@ -708,17 +481,11 @@ always @(*) begin
                 BK_1_round_19[15:8] = SM4_out_11;
                 BK_1_round_19[7:0]  = SM4_out_12;
             end
-            default: BK_1_round_19 = BK_1_round_19;
+            default: BK_1_round_19 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_19 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_19 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'hc: begin
                 B_1_round_19[31:24] = SM4_out_0;
@@ -726,17 +493,11 @@ always @(*) begin
                 B_1_round_19[15:8]  = SM4_out_2;
                 B_1_round_19[7:0]   = SM4_out_3;
             end
-            default: B_1_round_19 = B_1_round_19;
+            default: B_1_round_19 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_20 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_20 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'hc: begin
                 BK_0_round_20[31:24]= SM4_out_4;
@@ -744,17 +505,11 @@ always @(*) begin
                 BK_0_round_20[15:8] = SM4_out_6;
                 BK_0_round_20[7:0]  = SM4_out_7;
             end
-            default: BK_0_round_20 = BK_0_round_20;
+            default: BK_0_round_20 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_20 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_20 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'hc: begin
                 B_0_round_20[31:24] = SM4_out_8;
@@ -762,17 +517,11 @@ always @(*) begin
                 B_0_round_20[15:8]  = SM4_out_10;
                 B_0_round_20[7:0]   = SM4_out_11;
             end
-            default: B_0_round_20 = B_0_round_20;
+            default: B_0_round_20 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_21 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_21 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'hc: begin
                 BK_1_round_21[31:24]= SM4_out_12;
@@ -782,17 +531,11 @@ always @(*) begin
                 BK_1_round_21[15:8] = SM4_out_1;
                 BK_1_round_21[7:0]  = SM4_out_2;
             end
-            default: BK_1_round_21 = BK_1_round_21;
+            default: BK_1_round_21 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_21 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_21 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'hd: begin
                 B_1_round_21[31:24] = SM4_out_3;
@@ -800,17 +543,11 @@ always @(*) begin
                 B_1_round_21[15:8]  = SM4_out_5;
                 B_1_round_21[7:0]   = SM4_out_6;
             end
-            default: B_1_round_21 = B_1_round_21;
+            default: B_1_round_21 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_22 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_22 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'hd: begin
                 BK_0_round_22[31:24]= SM4_out_7;
@@ -818,17 +555,11 @@ always @(*) begin
                 BK_0_round_22[15:8] = SM4_out_9;
                 BK_0_round_22[7:0]  = SM4_out_10;
             end
-            default: BK_0_round_22 = BK_0_round_22;
+            default: BK_0_round_22 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_22 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_22 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'hd: begin
                 B_0_round_22[31:24] = SM4_out_11;
@@ -838,17 +569,11 @@ always @(*) begin
                 B_0_round_22[15:8]  = SM4_out_0;
                 B_0_round_22[7:0]   = SM4_out_1;
             end
-            default: B_0_round_22 = B_0_round_22;
+            default: B_0_round_22 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_23 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_23 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'he: begin
                 BK_1_round_23[31:24]= SM4_out_2;
@@ -856,17 +581,11 @@ always @(*) begin
                 BK_1_round_23[15:8] = SM4_out_4;
                 BK_1_round_23[7:0]  = SM4_out_5;
             end
-            default: BK_1_round_23 = BK_1_round_23;
+            default: BK_1_round_23 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_23 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_23 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'he: begin
                 B_1_round_23[31:24] = SM4_out_6;
@@ -874,17 +593,11 @@ always @(*) begin
                 B_1_round_23[15:8]  = SM4_out_8;
                 B_1_round_23[7:0]   = SM4_out_9;
             end
-            default: B_1_round_23 = B_1_round_23;
+            default: B_1_round_23 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_24 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_24 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'he: begin
                 BK_0_round_24[31:24]= SM4_out_10;
@@ -894,17 +607,11 @@ always @(*) begin
             6'hf: begin
                 BK_0_round_24[7:0]  = SM4_out_0;
             end
-            default: BK_0_round_24 = BK_0_round_24;
+            default: BK_0_round_24 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_24 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_24 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'hf: begin
                 B_0_round_24[31:24] = SM4_out_1;
@@ -912,17 +619,11 @@ always @(*) begin
                 B_0_round_24[15:8]  = SM4_out_3;
                 B_0_round_24[7:0]   = SM4_out_4;
             end
-            default: B_0_round_24 = B_0_round_24;
+            default: B_0_round_24 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_25 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_25 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'hf: begin
                 BK_1_round_25[31:24]= SM4_out_5;
@@ -930,17 +631,11 @@ always @(*) begin
                 BK_1_round_25[15:8] = SM4_out_7;
                 BK_1_round_25[7:0]  = SM4_out_8;
             end
-            default: BK_1_round_25 = BK_1_round_25;
+            default: BK_1_round_25 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_25 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_25 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'hf: begin
                 B_1_round_25[31:24] = SM4_out_9;
@@ -948,17 +643,11 @@ always @(*) begin
                 B_1_round_25[15:8]  = SM4_out_11;
                 B_1_round_25[7:0]   = SM4_out_12;
             end
-            default: B_1_round_25 = B_1_round_25;
+            default: B_1_round_25 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_26 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_26 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h10: begin
                 BK_0_round_26[31:24]= SM4_out_0;
@@ -966,17 +655,11 @@ always @(*) begin
                 BK_0_round_26[15:8] = SM4_out_2;
                 BK_0_round_26[7:0]  = SM4_out_3;
             end
-            default: BK_0_round_26 = BK_0_round_26;
+            default: BK_0_round_26 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_26 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_26 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h10: begin
                 B_0_round_26[31:24] = SM4_out_4;
@@ -984,17 +667,11 @@ always @(*) begin
                 B_0_round_26[15:8]  = SM4_out_6;
                 B_0_round_26[7:0]   = SM4_out_7;
             end
-            default: B_0_round_26 = B_0_round_26;
+            default: B_0_round_26 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_27 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_27 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h10: begin
                 BK_1_round_27[31:24]= SM4_out_8;
@@ -1002,17 +679,11 @@ always @(*) begin
                 BK_1_round_27[15:8] = SM4_out_10;
                 BK_1_round_27[7:0]  = SM4_out_11;
             end
-            default: BK_1_round_27 = BK_1_round_27;
+            default: BK_1_round_27 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_27 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_27 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h10: begin
                 B_1_round_27[31:24] = SM4_out_12;
@@ -1022,17 +693,11 @@ always @(*) begin
                 B_1_round_27[15:8]  = SM4_out_1;
                 B_1_round_27[7:0]   = SM4_out_2;
             end
-            default: B_1_round_27 = B_1_round_27;
+            default: B_1_round_27 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_28 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_28 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h11: begin
                 BK_0_round_28[31:24]= SM4_out_3;
@@ -1040,17 +705,11 @@ always @(*) begin
                 BK_0_round_28[15:8] = SM4_out_5;
                 BK_0_round_28[7:0]  = SM4_out_6;
             end
-            default: BK_0_round_28 = BK_0_round_28;
+            default: BK_0_round_28 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_28 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_28 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h11: begin
                 B_0_round_28[31:24] = SM4_out_7;
@@ -1058,17 +717,11 @@ always @(*) begin
                 B_0_round_28[15:8]  = SM4_out_9;
                 B_0_round_28[7:0]   = SM4_out_10;
             end
-            default: B_0_round_28 = B_0_round_28;
+            default: B_0_round_28 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_29 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_29 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h11: begin
                 BK_1_round_29[31:24]= SM4_out_11;
@@ -1078,17 +731,11 @@ always @(*) begin
                 BK_1_round_29[15:8] = SM4_out_0;
                 BK_1_round_29[7:0]  = SM4_out_1;
             end
-            default: BK_1_round_29 = BK_1_round_29;
+            default: BK_1_round_29 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_29 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_29 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h12: begin
                 B_1_round_29[31:24] = SM4_out_2;
@@ -1096,17 +743,11 @@ always @(*) begin
                 B_1_round_29[15:8]  = SM4_out_4;
                 B_1_round_29[7:0]   = SM4_out_5;
             end
-            default: B_1_round_29 = B_1_round_29;
+            default: B_1_round_29 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_30 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_30 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h12: begin
                 BK_0_round_30[31:24]= SM4_out_6;
@@ -1114,17 +755,11 @@ always @(*) begin
                 BK_0_round_30[15:8] = SM4_out_8;
                 BK_0_round_30[7:0]  = SM4_out_9;
             end
-            default: BK_0_round_30 = BK_0_round_30;
+            default: BK_0_round_30 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_30 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_30 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h12: begin
                 B_0_round_30[31:24] = SM4_out_10;
@@ -1134,17 +769,11 @@ always @(*) begin
             6'h13: begin
                 B_0_round_30[7:0]   = SM4_out_0;
             end
-            default: B_0_round_30 = B_0_round_30;
+            default: B_0_round_30 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_31 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_31 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h13: begin
                 BK_1_round_31[31:24]= SM4_out_1;
@@ -1152,17 +781,11 @@ always @(*) begin
                 BK_1_round_31[15:8] = SM4_out_3;
                 BK_1_round_31[7:0]  = SM4_out_4;
             end
-            default: BK_1_round_31 = BK_1_round_31;
+            default: BK_1_round_31 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_31 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_31 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h13: begin
                 B_1_round_31[31:24] = SM4_out_5;
@@ -1170,17 +793,11 @@ always @(*) begin
                 B_1_round_31[15:8]  = SM4_out_7;
                 B_1_round_31[7:0]   = SM4_out_8;
             end
-            default: B_1_round_31 = B_1_round_31;
+            default: B_1_round_31 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_32 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_32 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h14: begin
                 BK_0_round_32[31:24]= SM4_out_0;
@@ -1188,17 +805,11 @@ always @(*) begin
                 BK_0_round_32[15:8] = SM4_out_2;
                 BK_0_round_32[7:0]  = SM4_out_3;
             end
-            default: BK_0_round_32 = BK_0_round_32;
+            default: BK_0_round_32 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_32 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_32 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h14: begin
                 B_0_round_32[31:24] = SM4_out_4;
@@ -1206,17 +817,11 @@ always @(*) begin
                 B_0_round_32[15:8]  = SM4_out_6;
                 B_0_round_32[7:0]   = SM4_out_7;
             end
-            default: B_0_round_32 = B_0_round_32;
+            default: B_0_round_32 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_33 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_33 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h14: begin
                 BK_1_round_33[31:24]= SM4_out_8;
@@ -1224,17 +829,11 @@ always @(*) begin
                 BK_1_round_33[15:8] = SM4_out_10;
                 BK_1_round_33[7:0]  = SM4_out_11;
             end
-            default: BK_1_round_33 = BK_1_round_33;
+            default: BK_1_round_33 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_33 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_33 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h14: begin
                 B_1_round_33[31:24] = SM4_out_12;
@@ -1244,17 +843,11 @@ always @(*) begin
                 B_1_round_33[15:8]  = SM4_out_1;
                 B_1_round_33[7:0]   = SM4_out_2;
             end
-            default: B_1_round_33 = B_1_round_33;
+            default: B_1_round_33 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_34 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_34 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h15: begin
                 BK_0_round_34[31:24]= SM4_out_3;
@@ -1262,17 +855,11 @@ always @(*) begin
                 BK_0_round_34[15:8] = SM4_out_5;
                 BK_0_round_34[7:0]  = SM4_out_6;
             end
-            default: BK_0_round_34 = BK_0_round_34;
+            default: BK_0_round_34 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_34 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_34 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h15: begin
                 B_0_round_34[31:24] = SM4_out_7;
@@ -1280,17 +867,11 @@ always @(*) begin
                 B_0_round_34[15:8]  = SM4_out_9;
                 B_0_round_34[7:0]   = SM4_out_10;
             end
-            default: B_0_round_34 = B_0_round_34;
+            default: B_0_round_34 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_35 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_35 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h15: begin
                 BK_1_round_35[31:24]= SM4_out_11;
@@ -1300,17 +881,11 @@ always @(*) begin
                 BK_1_round_35[15:8] = SM4_out_0;
                 BK_1_round_35[7:0]  = SM4_out_1;
             end
-            default: BK_1_round_35 = BK_1_round_35;
+            default: BK_1_round_35 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_35 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_35 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h16: begin
                 B_1_round_35[31:24] = SM4_out_2;
@@ -1318,17 +893,11 @@ always @(*) begin
                 B_1_round_35[15:8]  = SM4_out_4;
                 B_1_round_35[7:0]   = SM4_out_5;
             end
-            default: B_1_round_35 = B_1_round_35;
+            default: B_1_round_35 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_36 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_36 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h16: begin
                 BK_0_round_36[31:24]= SM4_out_6;
@@ -1336,17 +905,11 @@ always @(*) begin
                 BK_0_round_36[15:8] = SM4_out_8;
                 BK_0_round_36[7:0]  = SM4_out_9;
             end
-            default: BK_0_round_36 = BK_0_round_36;
+            default: BK_0_round_36 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_36 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_36 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h16: begin
                 B_0_round_36[31:24] = SM4_out_10;
@@ -1360,17 +923,11 @@ always @(*) begin
                 B_0_round_36[15:8]  = B_0_round_36[15:8] ;
                 B_0_round_36[7:0]   = SM4_out_0;
             end
-            default: B_0_round_36 = B_0_round_36;
+            default: B_0_round_36 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_37 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_37 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h17: begin
                 BK_1_round_37[31:24]= SM4_out_1;
@@ -1378,17 +935,11 @@ always @(*) begin
                 BK_1_round_37[15:8] = SM4_out_3;
                 BK_1_round_37[7:0]  = SM4_out_4;
             end
-            default: BK_1_round_37 = BK_1_round_37;
+            default: BK_1_round_37 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_37 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_37 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h17: begin
                 B_1_round_37[31:24] = SM4_out_5;
@@ -1396,17 +947,11 @@ always @(*) begin
                 B_1_round_37[15:8]  = SM4_out_7;
                 B_1_round_37[7:0]   = SM4_out_8;
             end
-            default: B_1_round_37 = B_1_round_37;
+            default: B_1_round_37 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_38 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_38 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h17: begin
                 BK_0_round_38[31:24]= SM4_out_9;
@@ -1414,17 +959,11 @@ always @(*) begin
                 BK_0_round_38[15:8] = SM4_out_11;
                 BK_0_round_38[7:0]  = SM4_out_12;
             end
-            default: BK_0_round_38 = BK_0_round_38;
+            default: BK_0_round_38 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_38 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_38 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h18: begin
                 B_0_round_38[31:24] = SM4_out_0;
@@ -1432,17 +971,11 @@ always @(*) begin
                 B_0_round_38[15:8]  = SM4_out_2;
                 B_0_round_38[7:0]   = SM4_out_3;
             end
-            default: B_0_round_38 = B_0_round_38;
+            default: B_0_round_38 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_39 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_39 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h18: begin
                 BK_1_round_39[31:24]= SM4_out_4;
@@ -1450,17 +983,11 @@ always @(*) begin
                 BK_1_round_39[15:8] = SM4_out_6;
                 BK_1_round_39[7:0]  = SM4_out_7;
             end
-            default: BK_1_round_39 = BK_1_round_39;
+            default: BK_1_round_39 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_39 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_39 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h18: begin
                 B_1_round_39[31:24] = SM4_out_8;
@@ -1468,17 +995,11 @@ always @(*) begin
                 B_1_round_39[15:8]  = SM4_out_10;
                 B_1_round_39[7:0]   = SM4_out_11;
             end
-            default: B_1_round_39 = B_1_round_39;
+            default: B_1_round_39 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_40 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_40 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h18: begin
                 BK_0_round_40[31:24]= SM4_out_12;
@@ -1488,17 +1009,11 @@ always @(*) begin
                 BK_0_round_40[15:8] = SM4_out_1;
                 BK_0_round_40[7:0]  = SM4_out_2;
             end
-            default: BK_0_round_40 = BK_0_round_40;
+            default: BK_0_round_40 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_40 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_40 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h19: begin
                 B_0_round_40[31:24] = SM4_out_3;
@@ -1506,17 +1021,11 @@ always @(*) begin
                 B_0_round_40[15:8]  = SM4_out_5;
                 B_0_round_40[7:0]   = SM4_out_6;
             end
-            default: B_0_round_40 = B_0_round_40;
+            default: B_0_round_40 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_41 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_41 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h19: begin
                 BK_1_round_41[31:24]= SM4_out_7;
@@ -1524,17 +1033,11 @@ always @(*) begin
                 BK_1_round_41[15:8] = SM4_out_9;
                 BK_1_round_41[7:0]  = SM4_out_10;
             end
-            default: BK_1_round_41 = BK_1_round_41;
+            default: BK_1_round_41 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_41 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_41 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h19: begin
                 B_1_round_41[31:24] = SM4_out_11;
@@ -1544,17 +1047,11 @@ always @(*) begin
                 B_1_round_41[15:8]  = SM4_out_0;
                 B_1_round_41[7:0]   = SM4_out_1;
             end
-            default: B_1_round_41 = B_1_round_41;
+            default: B_1_round_41 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_42 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_42 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1a: begin
                 BK_0_round_42[31:24]= SM4_out_2;
@@ -1562,17 +1059,11 @@ always @(*) begin
                 BK_0_round_42[15:8] = SM4_out_4;
                 BK_0_round_42[7:0]  = SM4_out_5;
             end
-            default: BK_0_round_42 = BK_0_round_42;
+            default: BK_0_round_42 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_42 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_42 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1a: begin
                 B_0_round_42[31:24] = SM4_out_6;
@@ -1580,17 +1071,11 @@ always @(*) begin
                 B_0_round_42[15:8]  = SM4_out_8;
                 B_0_round_42[7:0]   = SM4_out_9;
             end
-            default: B_0_round_42 = B_0_round_42;
+            default: B_0_round_42 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_43 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_43 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1a: begin
                 BK_1_round_43[31:24]= SM4_out_10;
@@ -1600,17 +1085,11 @@ always @(*) begin
             6'h1b: begin
                 BK_1_round_43[7:0]  = SM4_out_0;
             end
-            default: BK_1_round_43 = BK_1_round_43;
+            default: BK_1_round_43 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_43 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_43 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1b: begin
                 B_1_round_43[31:24] = SM4_out_1;
@@ -1618,17 +1097,11 @@ always @(*) begin
                 B_1_round_43[15:8]  = SM4_out_3;
                 B_1_round_43[7:0]   = SM4_out_4;
             end
-            default: B_1_round_43 = B_1_round_43;
+            default: B_1_round_43 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_44 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_44 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1b: begin
                 BK_0_round_44[31:24]= SM4_out_5;
@@ -1636,17 +1109,11 @@ always @(*) begin
                 BK_0_round_44[15:8] = SM4_out_7;
                 BK_0_round_44[7:0]  = SM4_out_8;
             end
-            default: BK_0_round_44 = BK_0_round_44;
+            default: BK_0_round_44 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_44 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_44 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1b: begin
                 B_0_round_44[31:24] = SM4_out_9;
@@ -1654,17 +1121,11 @@ always @(*) begin
                 B_0_round_44[15:8]  = SM4_out_11;
                 B_0_round_44[7:0]   = SM4_out_12;
             end
-            default: B_0_round_44 = B_0_round_44;
+            default: B_0_round_44 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_45 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_45 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1c: begin
                 BK_1_round_45[31:24]= SM4_out_0;
@@ -1672,17 +1133,11 @@ always @(*) begin
                 BK_1_round_45[15:8] = SM4_out_2;
                 BK_1_round_45[7:0]  = SM4_out_3;
             end
-            default: BK_1_round_45 = BK_1_round_45;
+            default: BK_1_round_45 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_45 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_45 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1c: begin
                 B_1_round_45[31:24] = SM4_out_4;
@@ -1690,17 +1145,11 @@ always @(*) begin
                 B_1_round_45[15:8]  = SM4_out_6;
                 B_1_round_45[7:0]   = SM4_out_7;
             end
-            default: B_1_round_45 = B_1_round_45;
+            default: B_1_round_45 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_46 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_46 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1c: begin
                 BK_0_round_46[31:24]= SM4_out_8;
@@ -1708,17 +1157,11 @@ always @(*) begin
                 BK_0_round_46[15:8] = SM4_out_10;
                 BK_0_round_46[7:0]  = SM4_out_11;
             end
-            default: BK_0_round_46 = BK_0_round_46;
+            default: BK_0_round_46 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_46 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_46 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1c: begin
                 B_0_round_46[31:24] = SM4_out_12;
@@ -1728,17 +1171,11 @@ always @(*) begin
                 B_0_round_46[15:8]  = SM4_out_1;
                 B_0_round_46[7:0]   = SM4_out_2;
             end
-            default: B_0_round_46 = B_0_round_46;
+            default: B_0_round_46 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_47 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_47 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1d: begin
                 BK_1_round_47[31:24]= SM4_out_3;
@@ -1746,17 +1183,11 @@ always @(*) begin
                 BK_1_round_47[15:8] = SM4_out_5;
                 BK_1_round_47[7:0]  = SM4_out_6;
             end
-            default: BK_1_round_47 = BK_1_round_47;
+            default: BK_1_round_47 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_47 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_47 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1d: begin
                 B_1_round_47[31:24] = SM4_out_7;
@@ -1764,17 +1195,11 @@ always @(*) begin
                 B_1_round_47[15:8]  = SM4_out_9;
                 B_1_round_47[7:0]   = SM4_out_10;
             end
-            default: B_1_round_47 = B_1_round_47;
+            default: B_1_round_47 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_48 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_48 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1d: begin
                 BK_0_round_48[31:24]= SM4_out_11;
@@ -1784,17 +1209,11 @@ always @(*) begin
                 BK_0_round_48[15:8] = SM4_out_0;
                 BK_0_round_48[7:0]  = SM4_out_1;
             end
-            default: BK_0_round_48 = BK_0_round_48;
+            default: BK_0_round_48 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_48 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_48 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1e: begin
                 B_0_round_48[31:24] = SM4_out_2;
@@ -1802,17 +1221,11 @@ always @(*) begin
                 B_0_round_48[15:8]  = SM4_out_4;
                 B_0_round_48[7:0]   = SM4_out_5;
             end
-            default: B_0_round_48 = B_0_round_48;
+            default: B_0_round_48 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_49 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_49 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1e: begin
                 BK_1_round_49[31:24]= SM4_out_6;
@@ -1820,17 +1233,11 @@ always @(*) begin
                 BK_1_round_49[15:8] = SM4_out_8;
                 BK_1_round_49[7:0]  = SM4_out_9;
             end
-            default: BK_1_round_49 = BK_1_round_49;
+            default: BK_1_round_49 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_49 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_49 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1e: begin
                 B_1_round_49[31:24] = SM4_out_10;
@@ -1840,17 +1247,11 @@ always @(*) begin
             6'h1f: begin
                 B_1_round_49[7:0]   = SM4_out_0;
             end
-            default: B_1_round_49 = B_1_round_49;
+            default: B_1_round_49 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_50 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_50 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1f: begin
                 BK_0_round_50[31:24]= SM4_out_1;
@@ -1858,17 +1259,11 @@ always @(*) begin
                 BK_0_round_50[15:8] = SM4_out_3;
                 BK_0_round_50[7:0]  = SM4_out_4;
             end
-            default: BK_0_round_50 = BK_0_round_50;
+            default: BK_0_round_50 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_50 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_50 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1f: begin
                 B_0_round_50[31:24] = SM4_out_5;
@@ -1876,17 +1271,11 @@ always @(*) begin
                 B_0_round_50[15:8]  = SM4_out_7;
                 B_0_round_50[7:0]   = SM4_out_8;
             end
-            default: B_0_round_50 = B_0_round_50;
+            default: B_0_round_50 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_51 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_51 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h1f: begin
                 BK_1_round_51[31:24]= SM4_out_9;
@@ -1894,17 +1283,11 @@ always @(*) begin
                 BK_1_round_51[15:8] = SM4_out_11;
                 BK_1_round_51[7:0]  = SM4_out_12;
             end
-            default: BK_1_round_51 = BK_1_round_51;
+            default: BK_1_round_51 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_51 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_51 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h20: begin
                 B_1_round_51[31:24] = SM4_out_0;
@@ -1912,17 +1295,11 @@ always @(*) begin
                 B_1_round_51[15:8]  = SM4_out_2;
                 B_1_round_51[7:0]   = SM4_out_3;
             end
-            default: B_1_round_51 = B_1_round_51;
+            default: B_1_round_51 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_52 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_52 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h20: begin
                 BK_0_round_52[31:24]= SM4_out_4;
@@ -1930,17 +1307,11 @@ always @(*) begin
                 BK_0_round_52[15:8] = SM4_out_6;
                 BK_0_round_52[7:0]  = SM4_out_7;
             end
-            default: BK_0_round_52 = BK_0_round_52;
+            default: BK_0_round_52 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_52 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_52 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h20: begin
                 B_0_round_52[31:24] = SM4_out_8;
@@ -1948,17 +1319,11 @@ always @(*) begin
                 B_0_round_52[15:8]  = SM4_out_10;
                 B_0_round_52[7:0]   = SM4_out_11;
             end
-            default: B_0_round_52 = B_0_round_52;
+            default: B_0_round_52 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_53 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_53 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h20: begin
                 BK_1_round_53[31:24]= SM4_out_12;
@@ -1968,17 +1333,11 @@ always @(*) begin
                 BK_1_round_53[15:8] = SM4_out_1;
                 BK_1_round_53[7:0]  = SM4_out_2;
             end
-            default: BK_1_round_53 = BK_1_round_53;
+            default: BK_1_round_53 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_53 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_53 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h21: begin
                 B_1_round_53[31:24] = SM4_out_3;
@@ -1986,17 +1345,11 @@ always @(*) begin
                 B_1_round_53[15:8]  = SM4_out_5;
                 B_1_round_53[7:0]   = SM4_out_6;
             end
-            default: B_1_round_53 = B_1_round_53;
+            default: B_1_round_53 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_54 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_54 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h21: begin
                 BK_0_round_54[31:24]= SM4_out_7;
@@ -2004,17 +1357,11 @@ always @(*) begin
                 BK_0_round_54[15:8] = SM4_out_9;
                 BK_0_round_54[7:0]  = SM4_out_10;
             end
-            default: BK_0_round_54 = BK_0_round_54;
+            default: BK_0_round_54 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_54 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_54 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h21: begin
                 B_0_round_54[31:24] = SM4_out_11;
@@ -2024,17 +1371,11 @@ always @(*) begin
                 B_0_round_54[15:8]  = SM4_out_0;
                 B_0_round_54[7:0]   = SM4_out_1;
             end
-            default: B_0_round_54 = B_0_round_54;
+            default: B_0_round_54 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_55 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_55 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h22: begin
                 BK_1_round_55[31:24]= SM4_out_2;
@@ -2042,17 +1383,11 @@ always @(*) begin
                 BK_1_round_55[15:8] = SM4_out_4;
                 BK_1_round_55[7:0]  = SM4_out_5;
             end
-            default: BK_1_round_55 = BK_1_round_55;
+            default: BK_1_round_55 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_55 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_55 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h22: begin
                 B_1_round_55[31:24] = SM4_out_6;
@@ -2060,17 +1395,11 @@ always @(*) begin
                 B_1_round_55[15:8]  = SM4_out_8;
                 B_1_round_55[7:0]   = SM4_out_9;
             end
-            default: B_1_round_55 = B_1_round_55;
+            default: B_1_round_55 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_56 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_56 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h22: begin
                 BK_0_round_56[31:24]= SM4_out_10;
@@ -2080,9 +1409,8 @@ always @(*) begin
             6'h23: begin
                 BK_0_round_56[7:0]  = SM4_out_0;
             end
-            default: BK_0_round_56 = BK_0_round_56;
+            default: BK_0_round_56 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
@@ -2093,16 +1421,11 @@ always @(*) begin
                 B_0_round_56[15:8]  = SM4_out_3;
                 B_0_round_56[7:0]   = SM4_out_4;
             end
-            default: B_0_round_56 = B_0_round_56;
+            default: B_0_round_56 = 32'h0;
         endcase
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_57 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_57 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h23: begin
                 BK_1_round_57[31:24]= SM4_out_5;
@@ -2110,17 +1433,11 @@ always @(*) begin
                 BK_1_round_57[15:8] = SM4_out_7;
                 BK_1_round_57[7:0]  = SM4_out_8;
             end
-            default: BK_1_round_57 = BK_1_round_57;
+            default: BK_1_round_57 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_57 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_57 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h23: begin
                 B_1_round_57[31:24] = SM4_out_9;
@@ -2128,17 +1445,11 @@ always @(*) begin
                 B_1_round_57[15:8]  = SM4_out_11;
                 B_1_round_57[7:0]   = SM4_out_12;
             end
-            default: B_1_round_57 = B_1_round_57;
+            default: B_1_round_57 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_58 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_58 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h24: begin
                 BK_0_round_58[31:24]= SM4_out_0;
@@ -2146,17 +1457,11 @@ always @(*) begin
                 BK_0_round_58[15:8] = SM4_out_2;
                 BK_0_round_58[7:0]  = SM4_out_3;
             end
-            default: BK_0_round_58 = BK_0_round_58;
+            default: BK_0_round_58 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_58 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_58 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h24: begin
                 B_0_round_58[31:24] = SM4_out_4;
@@ -2164,17 +1469,11 @@ always @(*) begin
                 B_0_round_58[15:8]  = SM4_out_6;
                 B_0_round_58[7:0]   = SM4_out_7;
             end
-            default: B_0_round_58 = B_0_round_58;
+            default: B_0_round_58 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_59 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_59 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h24: begin
                 BK_1_round_59[31:24]= SM4_out_8;
@@ -2182,9 +1481,8 @@ always @(*) begin
                 BK_1_round_59[15:8] = SM4_out_10;
                 BK_1_round_59[7:0]  = SM4_out_11;
             end
-            default: BK_1_round_59 = BK_1_round_59;
+            default: BK_1_round_59 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
@@ -2202,11 +1500,6 @@ always @(*) begin
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_60 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_60 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h25: begin
                 BK_0_round_60[31:24]= SM4_out_3;
@@ -2214,17 +1507,11 @@ always @(*) begin
                 BK_0_round_60[15:8] = SM4_out_5;
                 BK_0_round_60[7:0]  = SM4_out_6;
             end
-            default: BK_0_round_60 = BK_0_round_60;
+            default: BK_0_round_60 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_60 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_60 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h25: begin
                 B_0_round_60[31:24] = SM4_out_7;
@@ -2232,17 +1519,11 @@ always @(*) begin
                 B_0_round_60[15:8]  = SM4_out_9;
                 B_0_round_60[7:0]   = SM4_out_10;
             end
-            default: B_0_round_60 = B_0_round_60;
+            default: B_0_round_60 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_61 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_61 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h25: begin
                 BK_1_round_61[31:24]= SM4_out_11;
@@ -2252,17 +1533,11 @@ always @(*) begin
                 BK_1_round_61[15:8] = SM4_out_0;
                 BK_1_round_61[7:0]  = SM4_out_1;
             end
-            default: BK_1_round_61 = BK_1_round_61;
+            default: BK_1_round_61 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_61 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_61 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h26: begin
                 B_1_round_61[31:24] = SM4_out_2;
@@ -2270,17 +1545,11 @@ always @(*) begin
                 B_1_round_61[15:8]  = SM4_out_4;
                 B_1_round_61[7:0]   = SM4_out_5;
             end
-            default: B_1_round_61 = B_1_round_61;
+            default: B_1_round_61 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_0_round_62 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_0_round_62 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h26: begin
                 BK_0_round_62[31:24]= SM4_out_6;
@@ -2288,17 +1557,11 @@ always @(*) begin
                 BK_0_round_62[15:8] = SM4_out_8;
                 BK_0_round_62[7:0]  = SM4_out_9;
             end
-            default: BK_0_round_62 = BK_0_round_62;
+            default: BK_0_round_62 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_0_round_62 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_0_round_62 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h26: begin
                 B_0_round_62[31:24] = SM4_out_10;
@@ -2308,17 +1571,11 @@ always @(*) begin
             6'h27: begin
                 B_0_round_62[7:0]   = SM4_out_0;
             end
-            default: B_0_round_62 = B_0_round_62;
+            default: B_0_round_62 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        BK_1_round_63 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        BK_1_round_63 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h27: begin
                 BK_1_round_63[31:24]= SM4_out_1;
@@ -2326,17 +1583,11 @@ always @(*) begin
                 BK_1_round_63[15:8] = SM4_out_3;
                 BK_1_round_63[7:0]  = SM4_out_4;
             end
-            default: BK_1_round_63 = BK_1_round_63;
+            default: BK_1_round_63 = 32'h0;
         endcase
-    end
 end
 
 always @(*) begin
-    if (!rstn) begin
-        B_1_round_63 = 32'h0;
-    end else if (cfg[2:1] == 2'b00 || cfg[2:1] == 2'b01 || cfg[2:1] == 2'b10) begin
-        B_1_round_63 = 32'h0;
-    end else begin
         case (clk_cnt_all)
             6'h27: begin
                 B_1_round_63[31:24] = SM4_out_5;
@@ -2344,7 +1595,6 @@ always @(*) begin
                 B_1_round_63[15:8]  = SM4_out_7;
                 B_1_round_63[7:0]   = SM4_out_8;
             end
-            default: B_1_round_63 = B_1_round_63;
+            default: B_1_round_63 = 32'h0;
         endcase
-    end
 end


### PR DESCRIPTION
## Summary
- remove reset and configuration checks from all combinational always blocks
- reset default values via case statements with zeroed default assignments

## Testing
- `iverilog -g2012 -tnull test.v` *(fails: test.v:2: syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_6897eb1420bc8322ac841f45a4ccf265